### PR TITLE
refactor: widen sidebar and show labels

### DIFF
--- a/client/src/components/Layout.tsx
+++ b/client/src/components/Layout.tsx
@@ -38,7 +38,7 @@ const Layout: React.FC = () => {
 
       {/* Sidebar */}
       <div className={`
-        fixed inset-y-0 left-0 z-30 w-20 lg:w-64 bg-white shadow-lg transform transition-transform duration-300 ease-in-out lg:translate-x-0 lg:static lg:inset-0
+        fixed inset-y-0 left-0 z-30 w-64 bg-white shadow-lg transform transition-transform duration-300 ease-in-out lg:translate-x-0 lg:static lg:inset-0
         ${sidebarOpen ? 'translate-x-0' : '-translate-x-full'}
       `}>
         <div className="flex items-center justify-between h-16 px-4 border-b border-gray-200">
@@ -51,7 +51,7 @@ const Layout: React.FC = () => {
           </button>
         </div>
 
-        <nav className="mt-4 lg:mt-8 px-2 lg:px-4">
+        <nav className="mt-4 lg:mt-8 px-4">
           <ul className="flex flex-col gap-2">
             {navigation.map((item) => {
               const Icon = item.icon;
@@ -61,25 +61,25 @@ const Layout: React.FC = () => {
                     to={item.href}
                     onClick={() => setSidebarOpen(false)}
                     className={`
-                      flex flex-col lg:flex-row items-center px-2 lg:px-4 py-3 text-xs lg:text-sm font-medium rounded-lg transition-colors duration-200
+                      flex flex-row items-center px-4 py-3 text-sm font-medium rounded-lg transition-colors duration-200
                       ${isCurrentPath(item.href)
                         ? 'bg-primary-100 text-primary-700 border-r-2 border-primary-600'
                         : 'text-gray-700 hover:bg-gray-100'
                       }
                     `}
                   >
-                    <Icon className="w-6 h-6 lg:w-5 lg:h-5 mb-1 lg:mb-0 mr-0 lg:mr-3" />
-                    <span className="hidden lg:inline">{item.name}</span>
+                    <Icon className="w-5 h-5 mr-3" />
+                    <span>{item.name}</span>
                   </Link>
-                </li>
+                  </li>
               );
             })}
           </ul>
         </nav>
 
         {/* User info and logout */}
-        <div className="absolute bottom-0 w-full p-2 lg:p-4 border-t border-gray-200">
-          <div className="flex flex-col lg:flex-row items-center mb-2 lg:mb-4">
+        <div className="absolute bottom-0 w-full p-4 border-t border-gray-200">
+          <div className="flex items-center mb-4">
             <div className="w-10 h-10 bg-primary-600 rounded-full flex items-center justify-center text-white text-base font-bold">
               {user ? getInitials(user.username) : 'U'}
             </div>
@@ -90,10 +90,10 @@ const Layout: React.FC = () => {
           </div>
           <button
             onClick={logout}
-            className="flex items-center w-full px-2 lg:px-4 py-2 text-xs lg:text-sm text-gray-700 hover:bg-gray-100 rounded-lg transition-colors duration-200"
+            className="flex items-center w-full px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 rounded-lg transition-colors duration-200"
           >
-            <FiLogOut className="w-5 h-5 mr-0 lg:mr-3" />
-            <span className="hidden lg:inline">Cerrar sesión</span>
+            <FiLogOut className="w-5 h-5 mr-3" />
+            <span>Cerrar sesión</span>
           </button>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- widen sidebar and display labels on all resolutions
- use horizontal layout for navigation items and logout button

## Testing
- `npm test -- --watchAll=false --passWithNoTests`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a39bdeaf508328b43e9381c0a6099c