### PR TITLE
Translate UI and server responses to Spanish

### DIFF
--- a/client/src/components/Layout.tsx
+++ b/client/src/components/Layout.tsx
@@ -113,7 +113,7 @@ const Layout: React.FC = () => {
             <div className="flex items-center space-x-4">
               <div className="hidden sm:block">
                 <h2 className="text-lg font-semibold text-gray-900">
-                  {navigation.find(item => isCurrentPath(item.href))?.name || 'Dashboard'}
+                  {navigation.find(item => isCurrentPath(item.href))?.name || 'Panel'}
                 </h2>
               </div>
             </div>

--- a/client/src/components/LoadingSpinner.tsx
+++ b/client/src/components/LoadingSpinner.tsx
@@ -24,7 +24,7 @@ const LoadingSpinner: React.FC<LoadingSpinnerProps> = ({
       <div className="fixed inset-0 flex items-center justify-center bg-white z-50">
         <div className="text-center">
           {spinner}
-          <p className="mt-2 text-gray-600">Loading...</p>
+          <p className="mt-2 text-gray-600">Cargando...</p>
         </div>
       </div>
     );

--- a/client/src/pages/Categories.tsx
+++ b/client/src/pages/Categories.tsx
@@ -52,7 +52,7 @@ const Categories: React.FC = () => {
       const response = await api.get('/categories');
       setCategories(response.data);
     } catch (error) {
-      console.error('Failed to load categories:', error);
+      console.error('Error al cargar las categorías:', error);
     } finally {
       setLoading(false);
     }
@@ -62,11 +62,11 @@ const Categories: React.FC = () => {
     const newErrors: Record<string, string> = {};
 
     if (!formData.name.trim()) {
-      newErrors.name = 'Category name is required';
+      newErrors.name = 'El nombre de la categoría es obligatorio';
     } else if (formData.name.trim().length < 2) {
-      newErrors.name = 'Category name must be at least 2 characters';
+      newErrors.name = 'El nombre de la categoría debe tener al menos 2 caracteres';
     } else if (formData.name.trim().length > 100) {
-      newErrors.name = 'Category name must be less than 100 characters';
+      newErrors.name = 'El nombre de la categoría debe tener menos de 100 caracteres';
     }
 
     // Check for duplicate names (excluding current category when editing)
@@ -76,15 +76,15 @@ const Categories: React.FC = () => {
     );
 
     if (isDuplicate) {
-      newErrors.name = 'A category with this name already exists';
+      newErrors.name = 'Ya existe una categoría con este nombre';
     }
 
     if (!formData.color || !/^#[0-9A-F]{6}$/i.test(formData.color)) {
-      newErrors.color = 'Please select a valid color';
+      newErrors.color = 'Selecciona un color válido';
     }
 
     if (!formData.icon) {
-      newErrors.icon = 'Please select an icon';
+      newErrors.icon = 'Selecciona un ícono';
     }
 
     setErrors(newErrors);
@@ -116,8 +116,8 @@ const Categories: React.FC = () => {
       resetForm();
       loadCategories();
     } catch (error: any) {
-      console.error('Failed to save category:', error);
-      setErrors({ submit: error.response?.data?.message || 'Failed to save category' });
+      console.error('Error al guardar la categoría:', error);
+      setErrors({ submit: error.response?.data?.message || 'Error al guardar la categoría' });
     }
   };
 
@@ -133,11 +133,11 @@ const Categories: React.FC = () => {
 
   const handleDelete = async (id: number, name: string, expenseCount: number) => {
     if (expenseCount > 0) {
-      alert(`Cannot delete "${name}" because it has ${expenseCount} associated expense(s). Please reassign or delete those expenses first.`);
+      alert(`No se puede eliminar "${name}" porque tiene ${expenseCount} gasto(s) asociado(s). Reasigna o elimina esos gastos primero.`);
       return;
     }
 
-    if (!window.confirm(`Are you sure you want to delete the category "${name}"?`)) {
+    if (!window.confirm(`¿Seguro que deseas eliminar la categoría "${name}"?`)) {
       return;
     }
 
@@ -145,8 +145,8 @@ const Categories: React.FC = () => {
       await api.delete(`/categories/${id}`);
       loadCategories();
     } catch (error: any) {
-      console.error('Failed to delete category:', error);
-      alert(error.response?.data?.message || 'Failed to delete category');
+      console.error('Error al eliminar la categoría:', error);
+      alert(error.response?.data?.message || 'Error al eliminar la categoría');
     }
   };
 
@@ -202,8 +202,8 @@ const Categories: React.FC = () => {
         {categories.length === 0 ? (
           <div className="text-center py-12">
             <FiTag className="mx-auto h-12 w-12 text-gray-400" />
-            <h3 className="mt-4 text-lg font-medium text-gray-900">No categories found</h3>
-            <p className="mt-2 text-gray-500">Get started by creating your first expense category.</p>
+            <h3 className="mt-4 text-lg font-medium text-gray-900">No se encontraron categorías</h3>
+            <p className="mt-2 text-gray-500">Comienza creando tu primera categoría de gastos.</p>
             <button
               onClick={() => {
                 setEditingCategory(null);
@@ -213,7 +213,7 @@ const Categories: React.FC = () => {
               className="btn-primary mt-4"
             >
               <FiPlus className="w-5 h-5 mr-2" />
-              Add Category
+              Agregar categoría
             </button>
           </div>
         ) : (
@@ -237,7 +237,7 @@ const Categories: React.FC = () => {
                           {category.name}
                         </h3>
                         <p className="text-sm text-gray-500">
-                          {category.expense_count} expense{category.expense_count !== 1 ? 's' : ''}
+                          {category.expense_count} gasto{category.expense_count !== 1 ? 's' : ''}
                         </p>
                       </div>
                     </div>
@@ -245,14 +245,14 @@ const Categories: React.FC = () => {
                       <button
                         onClick={() => handleEdit(category)}
                         className="text-blue-600 hover:text-blue-900 p-1"
-                        title="Edit category"
+                        title="Editar categoría"
                       >
                         <FiEdit className="w-4 h-4" />
                       </button>
                       <button
                         onClick={() => handleDelete(category.id, category.name, category.expense_count)}
                         className="text-red-600 hover:text-red-900 p-1"
-                        title="Delete category"
+                        title="Eliminar categoría"
                       >
                         <FiTrash2 className="w-4 h-4" />
                       </button>
@@ -271,7 +271,7 @@ const Categories: React.FC = () => {
           <div className="bg-white rounded-lg max-w-md w-full">
             <div className="p-6">
               <h3 className="text-lg font-medium mb-4">
-                {editingCategory ? 'Edit Category' : 'Add New Category'}
+                {editingCategory ? 'Editar categoría' : 'Agregar nueva categoría'}
               </h3>
 
               {errors.submit && (
@@ -283,14 +283,14 @@ const Categories: React.FC = () => {
               <form onSubmit={handleSubmit} className="space-y-4">
                 <div>
                   <label className="block text-sm font-medium text-gray-700 mb-1">
-                    Category Name *
+                    Nombre de la categoría *
                   </label>
                   <input
                     type="text"
                     value={formData.name}
                     onChange={(e) => setFormData(prev => ({ ...prev, name: e.target.value }))}
                     className={`input-field ${errors.name ? 'border-red-300' : ''}`}
-                    placeholder="Enter category name"
+                    placeholder="Ingresa el nombre de la categoría"
                     maxLength={100}
                   />
                   {errors.name && (
@@ -329,7 +329,7 @@ const Categories: React.FC = () => {
 
                 <div>
                   <label className="block text-sm font-medium text-gray-700 mb-1">
-                    Icon *
+                    Ícono *
                   </label>
                   <div className="grid grid-cols-6 gap-2">
                     {iconOptions.map((icon) => (
@@ -356,7 +356,7 @@ const Categories: React.FC = () => {
                 {/* Preview */}
                 <div className="border-t pt-4">
                   <label className="block text-sm font-medium text-gray-700 mb-2">
-                    Preview
+                    Vista previa
                   </label>
                   <div className="flex items-center space-x-3 p-3 bg-gray-50 rounded-md">
                     <div
@@ -366,7 +366,7 @@ const Categories: React.FC = () => {
                       {getIconComponent(formData.icon)}
                     </div>
                     <span className="text-sm font-medium text-gray-900">
-                      {formData.name || 'Category Name'}
+                      {formData.name || 'Nombre de la categoría'}
                     </span>
                   </div>
                 </div>
@@ -381,13 +381,13 @@ const Categories: React.FC = () => {
                     }}
                     className="flex-1 px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50"
                   >
-                    Cancel
+                    Cancelar
                   </button>
                   <button
                     type="submit"
                     className="flex-1 btn-primary"
                   >
-                    {editingCategory ? 'Update' : 'Create'} Category
+                    {editingCategory ? 'Actualizar' : 'Crear'} categoría
                   </button>
                 </div>
               </form>

--- a/client/src/pages/Expenses.tsx
+++ b/client/src/pages/Expenses.tsx
@@ -83,7 +83,7 @@ const Expenses: React.FC = () => {
         setFormData(prev => ({ ...prev, currencyId: currenciesRes.data[0].id.toString() }));
       }
     } catch (error) {
-      console.error('Failed to load initial data:', error);
+      console.error('Error al cargar los datos iniciales:', error);
     }
   };
 
@@ -102,7 +102,7 @@ const Expenses: React.FC = () => {
       setExpenses(response.data.expenses);
       setTotalPages(Math.ceil(response.data.total / 10));
     } catch (error) {
-      console.error('Failed to load expenses:', error);
+      console.error('Error al cargar los gastos:', error);
     } finally {
       setLoading(false);
     }
@@ -112,25 +112,25 @@ const Expenses: React.FC = () => {
     const newErrors: Record<string, string> = {};
 
     if (!formData.amount || parseFloat(formData.amount) <= 0) {
-      newErrors.amount = 'Amount must be greater than 0';
+      newErrors.amount = 'El monto debe ser mayor a 0';
     }
 
     if (!formData.description.trim()) {
-      newErrors.description = 'Description is required';
+      newErrors.description = 'La descripción es obligatoria';
     } else if (formData.description.trim().length > 500) {
-      newErrors.description = 'Description must be less than 500 characters';
+      newErrors.description = 'La descripción debe tener menos de 500 caracteres';
     }
 
     if (!formData.date) {
-      newErrors.date = 'Date is required';
+      newErrors.date = 'La fecha es obligatoria';
     }
 
     if (!formData.categoryId) {
-      newErrors.categoryId = 'Category is required';
+      newErrors.categoryId = 'La categoría es obligatoria';
     }
 
     if (!formData.currencyId) {
-      newErrors.currencyId = 'Currency is required';
+      newErrors.currencyId = 'La moneda es obligatoria';
     }
 
     setErrors(newErrors);
@@ -163,8 +163,8 @@ const Expenses: React.FC = () => {
       resetForm();
       loadExpenses();
     } catch (error: any) {
-      console.error('Failed to save expense:', error);
-      setErrors({ submit: error.response?.data?.message || 'Failed to save expense' });
+      console.error('Error al guardar el gasto:', error);
+      setErrors({ submit: error.response?.data?.message || 'Error al guardar el gasto' });
     }
   };
 
@@ -183,7 +183,7 @@ const Expenses: React.FC = () => {
   };
 
   const handleDelete = async (id: number) => {
-    if (!window.confirm('Are you sure you want to delete this expense?')) {
+    if (!window.confirm('¿Seguro que deseas eliminar este gasto?')) {
       return;
     }
 
@@ -191,7 +191,7 @@ const Expenses: React.FC = () => {
       await api.delete(`/expenses/${id}`);
       loadExpenses();
     } catch (error) {
-      console.error('Failed to delete expense:', error);
+      console.error('Error al eliminar el gasto:', error);
     }
   };
 
@@ -256,7 +256,7 @@ const Expenses: React.FC = () => {
               }}
               className="input-field"
             >
-              <option value="">All Categories</option>
+              <option value="">Todas las categorías</option>
               {categories.map((category) => (
                 <option key={category.id} value={category.name}>
                   {category.name}
@@ -267,31 +267,31 @@ const Expenses: React.FC = () => {
           
           <div>
             <label className="block text-sm font-medium text-gray-700 mb-2">
-              Sort by
+              Ordenar por
             </label>
             <select
               value={sortBy}
               onChange={(e) => setSortBy(e.target.value)}
               className="input-field"
             >
-              <option value="date">Date</option>
-              <option value="amount">Amount</option>
-              <option value="description">Description</option>
-              <option value="category">Category</option>
+              <option value="date">Fecha</option>
+              <option value="amount">Monto</option>
+              <option value="description">Descripción</option>
+              <option value="category">Categoría</option>
             </select>
           </div>
           
           <div>
             <label className="block text-sm font-medium text-gray-700 mb-2">
-              Order
+              Orden
             </label>
             <select
               value={sortOrder}
               onChange={(e) => setSortOrder(e.target.value as 'asc' | 'desc')}
               className="input-field"
             >
-              <option value="desc">Descending</option>
-              <option value="asc">Ascending</option>
+              <option value="desc">Descendente</option>
+              <option value="asc">Ascendente</option>
             </select>
           </div>
         </div>
@@ -302,8 +302,8 @@ const Expenses: React.FC = () => {
         {expenses.length === 0 ? (
           <div className="text-center py-12">
             <FiDollarSign className="mx-auto h-12 w-12 text-gray-400" />
-            <h3 className="mt-4 text-lg font-medium text-gray-900">No expenses found</h3>
-            <p className="mt-2 text-gray-500">Get started by adding your first expense.</p>
+            <h3 className="mt-4 text-lg font-medium text-gray-900">No se encontraron gastos</h3>
+            <p className="mt-2 text-gray-500">Comienza agregando tu primer gasto.</p>
             <button
               onClick={() => {
                 setEditingExpense(null);
@@ -313,7 +313,7 @@ const Expenses: React.FC = () => {
               className="btn-primary mt-4"
             >
               <FiPlus className="w-5 h-5 mr-2" />
-              Add Expense
+              Agregar gasto
             </button>
           </div>
         ) : (
@@ -322,22 +322,22 @@ const Expenses: React.FC = () => {
               <thead className="bg-gray-50">
                 <tr>
                   <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                    Description
+                    Descripción
                   </th>
                   <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                    Amount
+                    Monto
                   </th>
                   <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                    Category
+                    Categoría
                   </th>
                   <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                    Date
+                    Fecha
                   </th>
                   <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                    Type
+                    Tipo
                   </th>
                   <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
-                    Actions
+                    Acciones
                   </th>
                 </tr>
               </thead>
@@ -371,11 +371,11 @@ const Expenses: React.FC = () => {
                     <td className="px-6 py-4 whitespace-nowrap">
                       {expense.is_recurring ? (
                         <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800">
-                          Recurring
+                          Recurrente
                         </span>
                       ) : (
                         <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-800">
-                          One-time
+                          Único
                         </span>
                       )}
                     </td>
@@ -383,14 +383,14 @@ const Expenses: React.FC = () => {
                       <button
                         onClick={() => handleEdit(expense)}
                         className="text-blue-600 hover:text-blue-900 mr-4"
-                        title="Edit expense"
+                        title="Editar gasto"
                       >
                         <FiEdit className="w-4 h-4" />
                       </button>
                       <button
                         onClick={() => handleDelete(expense.id)}
                         className="text-red-600 hover:text-red-900"
-                        title="Delete expense"
+                        title="Eliminar gasto"
                       >
                         <FiTrash2 className="w-4 h-4" />
                       </button>
@@ -407,7 +407,7 @@ const Expenses: React.FC = () => {
           <div className="px-6 py-4 border-t border-gray-200">
             <div className="flex items-center justify-between">
               <div className="text-sm text-gray-700">
-                Page {currentPage} of {totalPages}
+                Página {currentPage} de {totalPages}
               </div>
               <div className="flex space-x-2">
                 <button
@@ -415,14 +415,14 @@ const Expenses: React.FC = () => {
                   disabled={currentPage === 1}
                   className="px-3 py-1 text-sm border rounded-md disabled:opacity-50 disabled:cursor-not-allowed"
                 >
-                  Previous
+                  Anterior
                 </button>
                 <button
                   onClick={() => setCurrentPage(prev => Math.min(totalPages, prev + 1))}
                   disabled={currentPage === totalPages}
                   className="px-3 py-1 text-sm border rounded-md disabled:opacity-50 disabled:cursor-not-allowed"
                 >
-                  Next
+                  Siguiente
                 </button>
               </div>
             </div>
@@ -436,7 +436,7 @@ const Expenses: React.FC = () => {
           <div className="bg-white rounded-lg max-w-md w-full max-h-screen overflow-y-auto">
             <div className="p-6">
               <h3 className="text-lg font-medium mb-4">
-                {editingExpense ? 'Edit Expense' : 'Add New Expense'}
+                {editingExpense ? 'Editar gasto' : 'Agregar nuevo gasto'}
               </h3>
 
               {errors.submit && (
@@ -448,14 +448,14 @@ const Expenses: React.FC = () => {
               <form onSubmit={handleSubmit} className="space-y-4">
                 <div>
                   <label className="block text-sm font-medium text-gray-700 mb-1">
-                    Description *
+                    Descripción *
                   </label>
                   <input
                     type="text"
                     value={formData.description}
                     onChange={(e) => setFormData(prev => ({ ...prev, description: e.target.value }))}
                     className={`input-field ${errors.description ? 'border-red-300' : ''}`}
-                    placeholder="Enter expense description"
+                    placeholder="Ingresa la descripción del gasto"
                   />
                   {errors.description && (
                     <p className="mt-1 text-sm text-red-600">{errors.description}</p>
@@ -464,7 +464,7 @@ const Expenses: React.FC = () => {
 
                 <div>
                   <label className="block text-sm font-medium text-gray-700 mb-1">
-                    Amount *
+                    Monto *
                   </label>
                   <input
                     type="number"
@@ -481,7 +481,7 @@ const Expenses: React.FC = () => {
 
                 <div>
                   <label className="block text-sm font-medium text-gray-700 mb-1">
-                    Date *
+                    Fecha *
                   </label>
                   <input
                     type="date"
@@ -496,14 +496,14 @@ const Expenses: React.FC = () => {
 
                 <div>
                   <label className="block text-sm font-medium text-gray-700 mb-1">
-                    Category *
+                    Categoría *
                   </label>
                   <select
                     value={formData.categoryId}
                     onChange={(e) => setFormData(prev => ({ ...prev, categoryId: e.target.value }))}
                     className={`input-field ${errors.categoryId ? 'border-red-300' : ''}`}
                   >
-                    <option value="">Select a category</option>
+                    <option value="">Selecciona una categoría</option>
                     {categories.map((category) => (
                       <option key={category.id} value={category.id}>
                         {category.name}
@@ -517,14 +517,14 @@ const Expenses: React.FC = () => {
 
                 <div>
                   <label className="block text-sm font-medium text-gray-700 mb-1">
-                    Currency *
+                    Moneda *
                   </label>
                   <select
                     value={formData.currencyId}
                     onChange={(e) => setFormData(prev => ({ ...prev, currencyId: e.target.value }))}
                     className={`input-field ${errors.currencyId ? 'border-red-300' : ''}`}
                   >
-                    <option value="">Select a currency</option>
+                    <option value="">Selecciona una moneda</option>
                     {currencies.map((currency) => (
                       <option key={currency.id} value={currency.id}>
                         {currency.code} - {currency.name}
@@ -544,24 +544,24 @@ const Expenses: React.FC = () => {
                       onChange={(e) => setFormData(prev => ({ ...prev, is_recurring: e.target.checked }))}
                       className="rounded border-gray-300 text-blue-600 focus:ring-blue-500"
                     />
-                    <span className="ml-2 text-sm text-gray-700">Recurring expense</span>
+                    <span className="ml-2 text-sm text-gray-700">Gasto recurrente</span>
                   </label>
                 </div>
 
                 {formData.is_recurring && (
                   <div>
                     <label className="block text-sm font-medium text-gray-700 mb-1">
-                      Frequency
+                      Frecuencia
                     </label>
                     <select
                       value={formData.recurring_frequency}
                       onChange={(e) => setFormData(prev => ({ ...prev, recurring_frequency: e.target.value }))}
                       className="input-field"
                     >
-                      <option value="daily">Daily</option>
-                      <option value="weekly">Weekly</option>
-                      <option value="monthly">Monthly</option>
-                      <option value="yearly">Yearly</option>
+                      <option value="daily">Diaria</option>
+                      <option value="weekly">Semanal</option>
+                      <option value="monthly">Mensual</option>
+                      <option value="yearly">Anual</option>
                     </select>
                   </div>
                 )}
@@ -576,13 +576,13 @@ const Expenses: React.FC = () => {
                     }}
                     className="flex-1 px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50"
                   >
-                    Cancel
+                    Cancelar
                   </button>
                   <button
                     type="submit"
                     className="flex-1 btn-primary"
                   >
-                    {editingExpense ? 'Update' : 'Add'} Expense
+                    {editingExpense ? 'Actualizar' : 'Agregar'} gasto
                   </button>
                 </div>
               </form>

--- a/client/src/pages/Login.tsx
+++ b/client/src/pages/Login.tsx
@@ -68,14 +68,14 @@ const Login: React.FC = () => {
               </label>
               <input
                 {...register('email', {
-                  required: 'Email is required',
+                  required: 'El correo electrónico es obligatorio',
                   pattern: {
                     value: /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/,
-                    message: 'Please enter a valid email address'
+                    message: 'Por favor ingresa un correo electrónico válido'
                   },
                   maxLength: {
                     value: 254,
-                    message: 'Email is too long'
+                    message: 'El correo electrónico es demasiado largo'
                   }
                 })}
                 type="email"
@@ -94,14 +94,14 @@ const Login: React.FC = () => {
               <div className="relative mt-1">
                 <input
                   {...register('password', {
-                    required: 'Password is required',
+                    required: 'La contraseña es obligatoria',
                     minLength: {
                       value: 8,
-                      message: 'Password must be at least 8 characters'
+                      message: 'La contraseña debe tener al menos 8 caracteres'
                     },
                     maxLength: {
                       value: 128,
-                      message: 'Password is too long'
+                      message: 'La contraseña es demasiado larga'
                     }
                   })}
                   type={showPassword ? 'text' : 'password'}

--- a/client/src/pages/Profile.tsx
+++ b/client/src/pages/Profile.tsx
@@ -31,21 +31,21 @@ const Profile: React.FC = () => {
     const newErrors: Record<string, string> = {};
 
     if (!profileForm.username.trim()) {
-      newErrors.username = 'Username is required';
+      newErrors.username = 'El nombre de usuario es obligatorio';
     } else if (profileForm.username.trim().length < 3) {
-      newErrors.username = 'Username must be at least 3 characters';
+      newErrors.username = 'El nombre de usuario debe tener al menos 3 caracteres';
     } else if (profileForm.username.trim().length > 30) {
-      newErrors.username = 'Username must be less than 30 characters';
+      newErrors.username = 'El nombre de usuario debe tener menos de 30 caracteres';
     } else if (!/^[a-zA-Z0-9_-]+$/.test(profileForm.username.trim())) {
-      newErrors.username = 'Username can only contain letters, numbers, underscores, and hyphens';
+      newErrors.username = 'El nombre de usuario solo puede contener letras, números, guiones y guiones bajos';
     }
 
     if (!profileForm.email.trim()) {
-      newErrors.email = 'Email is required';
+      newErrors.email = 'El correo electrónico es obligatorio';
     } else if (!/^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/.test(profileForm.email.trim())) {
-      newErrors.email = 'Please enter a valid email address';
+      newErrors.email = 'Por favor ingresa un correo electrónico válido';
     } else if (profileForm.email.length > 254) {
-      newErrors.email = 'Email is too long';
+      newErrors.email = 'El correo electrónico es demasiado largo';
     }
 
     return newErrors;
@@ -55,28 +55,28 @@ const Profile: React.FC = () => {
     const newErrors: Record<string, string> = {};
 
     if (!passwordForm.currentPassword) {
-      newErrors.currentPassword = 'Current password is required';
+      newErrors.currentPassword = 'La contraseña actual es obligatoria';
     }
 
     if (!passwordForm.newPassword) {
-      newErrors.newPassword = 'New password is required';
+      newErrors.newPassword = 'La nueva contraseña es obligatoria';
     } else if (passwordForm.newPassword.length < 8) {
-      newErrors.newPassword = 'New password must be at least 8 characters';
+      newErrors.newPassword = 'La nueva contraseña debe tener al menos 8 caracteres';
     } else if (passwordForm.newPassword.length > 128) {
-      newErrors.newPassword = 'New password is too long';
+      newErrors.newPassword = 'La nueva contraseña es demasiado larga';
     } else if (!/^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]/.test(passwordForm.newPassword)) {
-      newErrors.newPassword = 'Password must contain at least one uppercase letter, one lowercase letter, one number, and one special character';
+      newErrors.newPassword = 'La contraseña debe contener al menos una letra mayúscula, una letra minúscula, un número y un carácter especial';
     }
 
     if (!passwordForm.confirmPassword) {
-      newErrors.confirmPassword = 'Please confirm your new password';
+      newErrors.confirmPassword = 'Por favor confirma tu nueva contraseña';
     } else if (passwordForm.newPassword !== passwordForm.confirmPassword) {
-      newErrors.confirmPassword = 'Passwords do not match';
+      newErrors.confirmPassword = 'Las contraseñas no coinciden';
     }
 
-    if (passwordForm.currentPassword && passwordForm.newPassword && 
+    if (passwordForm.currentPassword && passwordForm.newPassword &&
         passwordForm.currentPassword === passwordForm.newPassword) {
-      newErrors.newPassword = 'New password must be different from current password';
+      newErrors.newPassword = 'La nueva contraseña debe ser diferente a la actual';
     }
 
     return newErrors;
@@ -101,15 +101,15 @@ const Profile: React.FC = () => {
         email: profileForm.email.trim().toLowerCase()
       });
 
-      setSuccessMessage('Profile updated successfully!');
+      setSuccessMessage('Perfil actualizado correctamente');
       
       // Update local user data (this would typically be handled by the auth context)
       // You might want to add an updateUser method to your AuthContext
       
     } catch (error: any) {
-      console.error('Failed to update profile:', error);
-      setErrors({ 
-        profile: error.response?.data?.message || 'Failed to update profile' 
+      console.error('Error al actualizar el perfil:', error);
+      setErrors({
+        profile: error.response?.data?.message || 'Error al actualizar el perfil'
       });
     } finally {
       setLoading(false);
@@ -135,7 +135,7 @@ const Profile: React.FC = () => {
         newPassword: passwordForm.newPassword
       });
 
-      setSuccessMessage('Password changed successfully!');
+      setSuccessMessage('Contraseña cambiada correctamente');
       setPasswordForm({
         currentPassword: '',
         newPassword: '',
@@ -143,9 +143,9 @@ const Profile: React.FC = () => {
       });
       
     } catch (error: any) {
-      console.error('Failed to change password:', error);
-      setErrors({ 
-        password: error.response?.data?.message || 'Failed to change password' 
+      console.error('Error al cambiar la contraseña:', error);
+      setErrors({
+        password: error.response?.data?.message || 'Error al cambiar la contraseña'
       });
     } finally {
       setLoading(false);
@@ -198,7 +198,7 @@ const Profile: React.FC = () => {
             <form onSubmit={handleProfileSubmit} className="space-y-4">
               <div>
                 <label className="block text-sm font-medium text-gray-700 mb-1">
-                  Username *
+                  Usuario *
                 </label>
                 <input
                   type="text"
@@ -208,7 +208,7 @@ const Profile: React.FC = () => {
                     clearMessages();
                   }}
                   className={`input-field ${errors.username ? 'border-red-300' : ''}`}
-                  placeholder="Enter your username"
+                  placeholder="Ingresa tu usuario"
                   maxLength={30}
                 />
                 {errors.username && (
@@ -218,7 +218,7 @@ const Profile: React.FC = () => {
 
               <div>
                 <label className="block text-sm font-medium text-gray-700 mb-1">
-                  Email Address *
+                  Correo electrónico *
                 </label>
                 <input
                   type="email"
@@ -228,7 +228,7 @@ const Profile: React.FC = () => {
                     clearMessages();
                   }}
                   className={`input-field ${errors.email ? 'border-red-300' : ''}`}
-                  placeholder="Enter your email"
+                  placeholder="Ingresa tu correo electrónico"
                   maxLength={254}
                 />
                 {errors.email && (
@@ -245,14 +245,14 @@ const Profile: React.FC = () => {
                   {loading ? (
                     <>
                       <LoadingSpinner size="sm" />
-                      <span className="ml-2">Updating...</span>
-                    </>
-                  ) : (
-                    <>
-                      <FiSave className="w-4 h-4 mr-2" />
-                      Update Profile
-                    </>
-                  )}
+                      <span className="ml-2">Actualizando...</span>
+                  </>
+                ) : (
+                  <>
+                    <FiSave className="w-4 h-4 mr-2" />
+                    Actualizar perfil
+                  </>
+                )}
                 </button>
               </div>
             </form>
@@ -264,7 +264,7 @@ const Profile: React.FC = () => {
           <div className="p-6">
             <h2 className="text-lg font-medium text-gray-900 mb-4 flex items-center">
               <FiKey className="w-5 h-5 mr-2" />
-              Change Password
+              Cambiar contraseña
             </h2>
 
             {errors.password && (
@@ -276,7 +276,7 @@ const Profile: React.FC = () => {
             <form onSubmit={handlePasswordSubmit} className="space-y-4">
               <div>
                 <label className="block text-sm font-medium text-gray-700 mb-1">
-                  Current Password *
+                  Contraseña actual *
                 </label>
                 <div className="relative">
                   <input
@@ -287,7 +287,7 @@ const Profile: React.FC = () => {
                       clearMessages();
                     }}
                     className={`input-field pr-10 ${errors.currentPassword ? 'border-red-300' : ''}`}
-                    placeholder="Enter current password"
+                    placeholder="Ingresa la contraseña actual"
                     maxLength={128}
                   />
                   <button
@@ -309,7 +309,7 @@ const Profile: React.FC = () => {
 
               <div>
                 <label className="block text-sm font-medium text-gray-700 mb-1">
-                  New Password *
+                  Nueva contraseña *
                 </label>
                 <div className="relative">
                   <input
@@ -320,7 +320,7 @@ const Profile: React.FC = () => {
                       clearMessages();
                     }}
                     className={`input-field pr-10 ${errors.newPassword ? 'border-red-300' : ''}`}
-                    placeholder="Enter new password"
+                    placeholder="Ingresa la nueva contraseña"
                     maxLength={128}
                   />
                   <button
@@ -342,7 +342,7 @@ const Profile: React.FC = () => {
 
               <div>
                 <label className="block text-sm font-medium text-gray-700 mb-1">
-                  Confirm New Password *
+                  Confirmar nueva contraseña *
                 </label>
                 <div className="relative">
                   <input
@@ -353,7 +353,7 @@ const Profile: React.FC = () => {
                       clearMessages();
                     }}
                     className={`input-field pr-10 ${errors.confirmPassword ? 'border-red-300' : ''}`}
-                    placeholder="Confirm new password"
+                    placeholder="Confirma la nueva contraseña"
                     maxLength={128}
                   />
                   <button
@@ -382,24 +382,24 @@ const Profile: React.FC = () => {
                   {loading ? (
                     <>
                       <LoadingSpinner size="sm" />
-                      <span className="ml-2">Changing...</span>
-                    </>
-                  ) : (
-                    <>
-                      <FiKey className="w-4 h-4 mr-2" />
-                      Change Password
-                    </>
-                  )}
+                      <span className="ml-2">Cambiando...</span>
+                  </>
+                ) : (
+                  <>
+                    <FiKey className="w-4 h-4 mr-2" />
+                    Cambiar contraseña
+                  </>
+                )}
                 </button>
               </div>
 
               <div className="text-sm text-gray-500 bg-gray-50 p-3 rounded-md">
-                <p className="font-medium mb-1">Password requirements:</p>
+                <p className="font-medium mb-1">Requisitos de la contraseña:</p>
                 <ul className="list-disc list-inside space-y-1">
-                  <li>At least 8 characters long</li>
-                  <li>Contains uppercase and lowercase letters</li>
-                  <li>Contains at least one number</li>
-                  <li>Contains at least one special character</li>
+                  <li>Al menos 8 caracteres</li>
+                  <li>Contiene letras mayúsculas y minúsculas</li>
+                  <li>Contiene al menos un número</li>
+                  <li>Contiene al menos un carácter especial</li>
                 </ul>
               </div>
             </form>
@@ -410,16 +410,16 @@ const Profile: React.FC = () => {
       {/* Account Information */}
       <div className="bg-white shadow-sm rounded-lg border">
         <div className="p-6">
-          <h2 className="text-lg font-medium text-gray-900 mb-4">Account Information</h2>
+          <h2 className="text-lg font-medium text-gray-900 mb-4">Información de la cuenta</h2>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
             <div>
-              <label className="block text-sm font-medium text-gray-700">Account Created</label>
+              <label className="block text-sm font-medium text-gray-700">Cuenta creada</label>
               <p className="mt-1 text-sm text-gray-900">
                 {user.created_at ? new Date(user.created_at).toLocaleDateString() : 'N/A'}
               </p>
             </div>
             <div>
-              <label className="block text-sm font-medium text-gray-700">Last Updated</label>
+              <label className="block text-sm font-medium text-gray-700">Última actualización</label>
               <p className="mt-1 text-sm text-gray-900">
                 {user.updated_at ? new Date(user.updated_at).toLocaleDateString() : 'N/A'}
               </p>

--- a/client/src/pages/Register.tsx
+++ b/client/src/pages/Register.tsx
@@ -30,7 +30,7 @@ const Register: React.FC = () => {
 
   const onSubmit = async (data: RegisterFormData) => {
     if (data.password !== data.confirmPassword) {
-      setError('confirmPassword', { message: 'Passwords do not match' });
+      setError('confirmPassword', { message: 'Las contraseñas no coinciden' });
       return;
     }
 
@@ -79,18 +79,18 @@ const Register: React.FC = () => {
               </label>
               <input
                 {...register('username', {
-                  required: 'Username is required',
+                  required: 'El nombre de usuario es obligatorio',
                   minLength: {
                     value: 3,
-                    message: 'Username must be at least 3 characters'
+                    message: 'El nombre de usuario debe tener al menos 3 caracteres'
                   },
                   maxLength: {
                     value: 30,
-                    message: 'Username must be less than 30 characters'
+                    message: 'El nombre de usuario debe tener menos de 30 caracteres'
                   },
                   pattern: {
                     value: /^[a-zA-Z0-9_-]+$/,
-                    message: 'Username can only contain letters, numbers, underscores, and hyphens'
+                    message: 'El nombre de usuario solo puede contener letras, números, guiones y guiones bajos'
                   }
                 })}
                 type="text"
@@ -108,14 +108,14 @@ const Register: React.FC = () => {
               </label>
               <input
                 {...register('email', {
-                  required: 'Email is required',
+                  required: 'El correo electrónico es obligatorio',
                   pattern: {
                     value: /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/,
-                    message: 'Please enter a valid email address'
+                    message: 'Por favor ingresa un correo electrónico válido'
                   },
                   maxLength: {
                     value: 254,
-                    message: 'Email is too long'
+                    message: 'El correo electrónico es demasiado largo'
                   }
                 })}
                 type="email"
@@ -134,18 +134,18 @@ const Register: React.FC = () => {
               <div className="relative mt-1">
                 <input
                   {...register('password', {
-                    required: 'Password is required',
+                    required: 'La contraseña es obligatoria',
                     minLength: {
                       value: 8,
-                      message: 'Password must be at least 8 characters'
+                      message: 'La contraseña debe tener al menos 8 caracteres'
                     },
                     maxLength: {
                       value: 128,
-                      message: 'Password is too long'
+                      message: 'La contraseña es demasiado larga'
                     },
                     pattern: {
                       value: /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]/,
-                      message: 'Password must contain at least one uppercase letter, one lowercase letter, one number, and one special character'
+                      message: 'La contraseña debe contener al menos una letra mayúscula, una letra minúscula, un número y un carácter especial'
                     }
                   })}
                   type={showPassword ? 'text' : 'password'}
@@ -176,8 +176,8 @@ const Register: React.FC = () => {
               <div className="relative mt-1">
                 <input
                   {...register('confirmPassword', {
-                    required: 'Please confirm your password',
-                    validate: (value) => value === password || 'Passwords do not match'
+                    required: 'Por favor confirma tu contraseña',
+                    validate: (value) => value === password || 'Las contraseñas no coinciden'
                   })}
                   type={showConfirmPassword ? 'text' : 'password'}
                   className="input-field pr-10"

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -12,21 +12,21 @@ router.post('/register', async (req, res) => {
     const { username, email, password } = req.body;
 
     if (!username || !email || !password) {
-      return res.status(400).json({ message: 'All fields are required' });
+      return res.status(400).json({ message: 'Todos los campos son obligatorios' });
     }
 
     if (password.length < 6) {
-      return res.status(400).json({ message: 'Password must be at least 6 characters' });
+      return res.status(400).json({ message: 'La contraseña debe tener al menos 6 caracteres' });
     }
 
     // Check if user already exists
     db.get('SELECT id FROM users WHERE email = ? OR username = ?', [email, username], async (err, existingUser) => {
       if (err) {
-        return res.status(500).json({ message: 'Database error' });
+        return res.status(500).json({ message: 'Error de base de datos' });
       }
 
       if (existingUser) {
-        return res.status(400).json({ message: 'User already exists' });
+        return res.status(400).json({ message: 'El usuario ya existe' });
       }
 
       // Hash password
@@ -39,20 +39,20 @@ router.post('/register', async (req, res) => {
         [username, email, passwordHash],
         function(err) {
           if (err) {
-            return res.status(500).json({ message: 'Error creating user' });
+            return res.status(500).json({ message: 'Error al crear el usuario' });
           }
 
           const userId = this.lastID;
 
           // Create default categories for new user
           const defaultCategories = [
-            { name: 'Food & Dining', color: '#EF4444', icon: 'utensils' },
-            { name: 'Transportation', color: '#3B82F6', icon: 'car' },
-            { name: 'Shopping', color: '#10B981', icon: 'shopping-bag' },
-            { name: 'Entertainment', color: '#F59E0B', icon: 'film' },
-            { name: 'Bills & Utilities', color: '#8B5CF6', icon: 'receipt' },
-            { name: 'Health & Fitness', color: '#EC4899', icon: 'heart' },
-            { name: 'Subscriptions', color: '#6366F1', icon: 'credit-card' }
+            { name: 'Comida y restaurante', color: '#EF4444', icon: 'utensils' },
+            { name: 'Transporte', color: '#3B82F6', icon: 'car' },
+            { name: 'Compras', color: '#10B981', icon: 'shopping-bag' },
+            { name: 'Entretenimiento', color: '#F59E0B', icon: 'film' },
+            { name: 'Facturas y servicios', color: '#8B5CF6', icon: 'receipt' },
+            { name: 'Salud y fitness', color: '#EC4899', icon: 'heart' },
+            { name: 'Suscripciones', color: '#6366F1', icon: 'credit-card' }
           ];
 
           const insertCategory = db.prepare('INSERT INTO categories (user_id, name, color, icon) VALUES (?, ?, ?, ?)');
@@ -71,7 +71,7 @@ router.post('/register', async (req, res) => {
           );
 
           res.status(201).json({
-            message: 'User created successfully',
+            message: 'Usuario creado correctamente',
             token,
             user: {
               id: userId,
@@ -83,7 +83,7 @@ router.post('/register', async (req, res) => {
       );
     });
   } catch (error) {
-    res.status(500).json({ message: 'Server error' });
+    res.status(500).json({ message: 'Error del servidor' });
   }
 });
 
@@ -93,22 +93,22 @@ router.post('/login', (req, res) => {
     const { email, password } = req.body;
 
     if (!email || !password) {
-      return res.status(400).json({ message: 'Email and password are required' });
+      return res.status(400).json({ message: 'El correo y la contraseña son obligatorios' });
     }
 
     db.get('SELECT * FROM users WHERE email = ?', [email], async (err, user) => {
       if (err) {
-        return res.status(500).json({ message: 'Database error' });
+        return res.status(500).json({ message: 'Error de base de datos' });
       }
 
       if (!user) {
-        return res.status(400).json({ message: 'Invalid credentials' });
+        return res.status(400).json({ message: 'Credenciales inválidas' });
       }
 
       const isValidPassword = await bcrypt.compare(password, user.password_hash);
 
       if (!isValidPassword) {
-        return res.status(400).json({ message: 'Invalid credentials' });
+        return res.status(400).json({ message: 'Credenciales inválidas' });
       }
 
       // Generate JWT token
@@ -119,7 +119,7 @@ router.post('/login', (req, res) => {
       );
 
       res.json({
-        message: 'Login successful',
+        message: 'Inicio de sesión exitoso',
         token,
         user: {
           id: user.id,
@@ -129,7 +129,7 @@ router.post('/login', (req, res) => {
       });
     });
   } catch (error) {
-    res.status(500).json({ message: 'Server error' });
+    res.status(500).json({ message: 'Error del servidor' });
   }
 });
 
@@ -147,22 +147,22 @@ router.put('/change-password', authMiddleware, async (req, res) => {
     const userId = req.user.id;
 
     if (!currentPassword || !newPassword) {
-      return res.status(400).json({ message: 'Current and new password are required' });
+      return res.status(400).json({ message: 'La contraseña actual y la nueva son obligatorias' });
     }
 
     if (newPassword.length < 6) {
-      return res.status(400).json({ message: 'New password must be at least 6 characters' });
+      return res.status(400).json({ message: 'La nueva contraseña debe tener al menos 6 caracteres' });
     }
 
     db.get('SELECT password_hash FROM users WHERE id = ?', [userId], async (err, user) => {
       if (err) {
-        return res.status(500).json({ message: 'Database error' });
+        return res.status(500).json({ message: 'Error de base de datos' });
       }
 
       const isValidPassword = await bcrypt.compare(currentPassword, user.password_hash);
 
       if (!isValidPassword) {
-        return res.status(400).json({ message: 'Current password is incorrect' });
+        return res.status(400).json({ message: 'La contraseña actual es incorrecta' });
       }
 
       const saltRounds = 12;
@@ -172,15 +172,15 @@ router.put('/change-password', authMiddleware, async (req, res) => {
         [newPasswordHash, userId], 
         function(err) {
           if (err) {
-            return res.status(500).json({ message: 'Error updating password' });
+            return res.status(500).json({ message: 'Error al actualizar la contraseña' });
           }
 
-          res.json({ message: 'Password updated successfully' });
+          res.json({ message: 'Contraseña actualizada correctamente' });
         }
       );
     });
   } catch (error) {
-    res.status(500).json({ message: 'Server error' });
+    res.status(500).json({ message: 'Error del servidor' });
   }
 });
 

--- a/server/routes/categories.js
+++ b/server/routes/categories.js
@@ -21,7 +21,7 @@ router.get('/', authMiddleware, (req, res) => {
 
   db.all(query, [userId], (err, categories) => {
     if (err) {
-      return res.status(500).json({ message: 'Database error' });
+      return res.status(500).json({ message: 'Error de base de datos' });
     }
 
     res.json(categories);
@@ -45,11 +45,11 @@ router.get('/:id', authMiddleware, (req, res) => {
 
   db.get(query, [categoryId, userId], (err, category) => {
     if (err) {
-      return res.status(500).json({ message: 'Database error' });
+      return res.status(500).json({ message: 'Error de base de datos' });
     }
 
     if (!category) {
-      return res.status(404).json({ message: 'Category not found' });
+      return res.status(404).json({ message: 'Categoría no encontrada' });
     }
 
     res.json(category);
@@ -62,38 +62,38 @@ router.post('/', authMiddleware, (req, res) => {
   const { name, color = '#3B82F6', icon = 'folder' } = req.body;
 
   if (!name) {
-    return res.status(400).json({ message: 'Category name is required' });
+    return res.status(400).json({ message: 'El nombre de la categoría es obligatorio' });
   }
 
   if (name.length > 100) {
-    return res.status(400).json({ message: 'Category name must be 100 characters or less' });
+    return res.status(400).json({ message: 'El nombre de la categoría debe tener 100 caracteres o menos' });
   }
 
   // Check if category name already exists for this user
   db.get('SELECT id FROM categories WHERE user_id = ? AND name = ?', [userId, name], (err, existingCategory) => {
     if (err) {
-      return res.status(500).json({ message: 'Database error' });
+      return res.status(500).json({ message: 'Error de base de datos' });
     }
 
     if (existingCategory) {
-      return res.status(400).json({ message: 'Category with this name already exists' });
+      return res.status(400).json({ message: 'Ya existe una categoría con este nombre' });
     }
 
     const query = 'INSERT INTO categories (user_id, name, color, icon) VALUES (?, ?, ?, ?)';
 
     db.run(query, [userId, name, color, icon], function(err) {
       if (err) {
-        return res.status(500).json({ message: 'Error creating category' });
+        return res.status(500).json({ message: 'Error al crear la categoría' });
       }
 
       // Get the created category
       db.get('SELECT * FROM categories WHERE id = ?', [this.lastID], (err, category) => {
         if (err) {
-          return res.status(500).json({ message: 'Error retrieving created category' });
+          return res.status(500).json({ message: 'Error al obtener la categoría creada' });
         }
 
         res.status(201).json({
-          message: 'Category created successfully',
+          message: 'Categoría creada correctamente',
           category: {
             ...category,
             expense_count: 0,
@@ -112,22 +112,22 @@ router.put('/:id', authMiddleware, (req, res) => {
   const { name, color, icon } = req.body;
 
   if (!name) {
-    return res.status(400).json({ message: 'Category name is required' });
+    return res.status(400).json({ message: 'El nombre de la categoría es obligatorio' });
   }
 
   if (name.length > 100) {
-    return res.status(400).json({ message: 'Category name must be 100 characters or less' });
+    return res.status(400).json({ message: 'El nombre de la categoría debe tener 100 caracteres o menos' });
   }
 
   // Check if category name already exists for this user (excluding current category)
   db.get('SELECT id FROM categories WHERE user_id = ? AND name = ? AND id != ?', 
     [userId, name, categoryId], (err, existingCategory) => {
     if (err) {
-      return res.status(500).json({ message: 'Database error' });
+      return res.status(500).json({ message: 'Error de base de datos' });
     }
 
     if (existingCategory) {
-      return res.status(400).json({ message: 'Category with this name already exists' });
+      return res.status(400).json({ message: 'Ya existe una categoría con este nombre' });
     }
 
     const query = `
@@ -138,11 +138,11 @@ router.put('/:id', authMiddleware, (req, res) => {
 
     db.run(query, [name, color, icon, categoryId, userId], function(err) {
       if (err) {
-        return res.status(500).json({ message: 'Error updating category' });
+        return res.status(500).json({ message: 'Error al actualizar la categoría' });
       }
 
       if (this.changes === 0) {
-        return res.status(404).json({ message: 'Category not found' });
+        return res.status(404).json({ message: 'Categoría no encontrada' });
       }
 
       // Get the updated category with stats
@@ -158,11 +158,11 @@ router.put('/:id', authMiddleware, (req, res) => {
 
       db.get(selectQuery, [categoryId], (err, category) => {
         if (err) {
-          return res.status(500).json({ message: 'Error retrieving updated category' });
+          return res.status(500).json({ message: 'Error al obtener la categoría actualizada' });
         }
 
         res.json({
-          message: 'Category updated successfully',
+          message: 'Categoría actualizada correctamente',
           category
         });
       });
@@ -178,25 +178,25 @@ router.delete('/:id', authMiddleware, (req, res) => {
   // Check if category has expenses
   db.get('SELECT COUNT(*) as count FROM expenses WHERE category_id = ?', [categoryId], (err, result) => {
     if (err) {
-      return res.status(500).json({ message: 'Database error' });
+      return res.status(500).json({ message: 'Error de base de datos' });
     }
 
     if (result.count > 0) {
-      return res.status(400).json({ 
-        message: 'Cannot delete category with existing expenses. Please move or delete all expenses first.' 
+      return res.status(400).json({
+        message: 'No se puede eliminar la categoría porque tiene gastos asociados. Mueve o elimina todos los gastos primero.'
       });
     }
 
     db.run('DELETE FROM categories WHERE id = ? AND user_id = ?', [categoryId, userId], function(err) {
       if (err) {
-        return res.status(500).json({ message: 'Error deleting category' });
+        return res.status(500).json({ message: 'Error al eliminar la categoría' });
       }
 
       if (this.changes === 0) {
-        return res.status(404).json({ message: 'Category not found' });
+        return res.status(404).json({ message: 'Categoría no encontrada' });
       }
 
-      res.json({ message: 'Category deleted successfully' });
+      res.json({ message: 'Categoría eliminada correctamente' });
     });
   });
 });

--- a/server/routes/currencies.js
+++ b/server/routes/currencies.js
@@ -10,7 +10,7 @@ const router = express.Router();
 router.get('/', authMiddleware, (req, res) => {
   db.all('SELECT * FROM currencies ORDER BY code ASC', (err, currencies) => {
     if (err) {
-      return res.status(500).json({ message: 'Database error' });
+      return res.status(500).json({ message: 'Error de base de datos' });
     }
 
     res.json(currencies);
@@ -21,13 +21,13 @@ router.get('/', authMiddleware, (req, res) => {
 router.post('/update-rates', authMiddleware, async (req, res) => {
   try {
     await currencyService.updateExchangeRates();
-    res.json({ 
-      message: 'Exchange rates update triggered successfully',
+    res.json({
+      message: 'Actualización de tasas de cambio iniciada correctamente',
       updatedAt: new Date().toISOString()
     });
   } catch (error) {
-    res.status(500).json({ 
-      message: 'Error updating exchange rates. Please try again later.',
+    res.status(500).json({
+      message: 'Error al actualizar las tasas de cambio. Por favor intenta de nuevo más tarde.',
       error: error.message
     });
   }
@@ -39,8 +39,8 @@ router.post('/convert', authMiddleware, async (req, res) => {
     const { amount, fromCurrency, toCurrency } = req.body;
 
     if (!amount || !fromCurrency || !toCurrency) {
-      return res.status(400).json({ 
-        message: 'Amount, fromCurrency, and toCurrency are required' 
+      return res.status(400).json({
+        message: 'Se requieren monto, moneda origen y moneda destino'
       });
     }
 
@@ -71,7 +71,7 @@ router.get('/stats', authMiddleware, (req, res) => {
 
   db.all(query, [userId], (err, stats) => {
     if (err) {
-      return res.status(500).json({ message: 'Database error' });
+      return res.status(500).json({ message: 'Error de base de datos' });
     }
 
     res.json(stats);

--- a/server/routes/expenses.js
+++ b/server/routes/expenses.js
@@ -46,7 +46,7 @@ router.get('/', authMiddleware, (req, res) => {
 
   db.all(query, params, (err, expenses) => {
     if (err) {
-      return res.status(500).json({ message: 'Database error' });
+      return res.status(500).json({ message: 'Error de base de datos' });
     }
 
     // Get total count
@@ -75,7 +75,7 @@ router.get('/', authMiddleware, (req, res) => {
 
     db.get(countQuery, countParams, (err, countResult) => {
       if (err) {
-        return res.status(500).json({ message: 'Database error' });
+        return res.status(500).json({ message: 'Error de base de datos' });
       }
 
       res.json({
@@ -104,11 +104,11 @@ router.get('/:id', authMiddleware, (req, res) => {
 
   db.get(query, [expenseId, userId], (err, expense) => {
     if (err) {
-      return res.status(500).json({ message: 'Database error' });
+      return res.status(500).json({ message: 'Error de base de datos' });
     }
 
     if (!expense) {
-      return res.status(404).json({ message: 'Expense not found' });
+      return res.status(404).json({ message: 'Gasto no encontrado' });
     }
 
     res.json(expense);
@@ -134,11 +134,11 @@ router.post('/', authMiddleware, (req, res) => {
   const resolvedCurrencyId = currencyId || currency_id;
 
   if (!resolvedCategoryId || !resolvedCurrencyId || !amount || !description || !date) {
-    return res.status(400).json({ message: 'All required fields must be provided' });
+    return res.status(400).json({ message: 'Todos los campos obligatorios deben proporcionarse' });
   }
 
   if (amount <= 0) {
-    return res.status(400).json({ message: 'Amount must be greater than 0' });
+    return res.status(400).json({ message: 'El monto debe ser mayor a 0' });
   }
 
   // Calculate next due date for recurring expenses
@@ -172,7 +172,7 @@ router.post('/', authMiddleware, (req, res) => {
     isRecurring, recurringFrequency, nextDueDate?.toISOString().split('T')[0]
   ], function(err) {
     if (err) {
-      return res.status(500).json({ message: 'Error creating expense' });
+      return res.status(500).json({ message: 'Error al crear el gasto' });
     }
 
     // Get the created expense with joined data
@@ -185,16 +185,16 @@ router.post('/', authMiddleware, (req, res) => {
       WHERE e.id = ?
     `;
 
-    db.get(selectQuery, [this.lastID], (err, expense) => {
-      if (err) {
-        return res.status(500).json({ message: 'Error retrieving created expense' });
-      }
+      db.get(selectQuery, [this.lastID], (err, expense) => {
+        if (err) {
+          return res.status(500).json({ message: 'Error al obtener el gasto creado' });
+        }
 
-      res.status(201).json({
-        message: 'Expense created successfully',
-        expense
+        res.status(201).json({
+          message: 'Gasto creado correctamente',
+          expense
+        });
       });
-    });
   });
 });
 
@@ -218,11 +218,11 @@ router.put('/:id', authMiddleware, (req, res) => {
   const resolvedCurrencyId = currencyId || currency_id;
 
   if (!resolvedCategoryId || !resolvedCurrencyId || !amount || !description || !date) {
-    return res.status(400).json({ message: 'All required fields must be provided' });
+    return res.status(400).json({ message: 'Todos los campos obligatorios deben proporcionarse' });
   }
 
   if (amount <= 0) {
-    return res.status(400).json({ message: 'Amount must be greater than 0' });
+    return res.status(400).json({ message: 'El monto debe ser mayor a 0' });
   }
 
   // Calculate next due date for recurring expenses
@@ -258,11 +258,11 @@ router.put('/:id', authMiddleware, (req, res) => {
     expenseId, userId
   ], function(err) {
     if (err) {
-      return res.status(500).json({ message: 'Error updating expense' });
+      return res.status(500).json({ message: 'Error al actualizar el gasto' });
     }
 
     if (this.changes === 0) {
-      return res.status(404).json({ message: 'Expense not found' });
+      return res.status(404).json({ message: 'Gasto no encontrado' });
     }
 
     // Get the updated expense with joined data
@@ -275,16 +275,16 @@ router.put('/:id', authMiddleware, (req, res) => {
       WHERE e.id = ?
     `;
 
-    db.get(selectQuery, [expenseId], (err, expense) => {
-      if (err) {
-        return res.status(500).json({ message: 'Error retrieving updated expense' });
-      }
+      db.get(selectQuery, [expenseId], (err, expense) => {
+        if (err) {
+          return res.status(500).json({ message: 'Error al obtener el gasto actualizado' });
+        }
 
-      res.json({
-        message: 'Expense updated successfully',
-        expense
+        res.json({
+          message: 'Gasto actualizado correctamente',
+          expense
+        });
       });
-    });
   });
 });
 
@@ -295,14 +295,14 @@ router.delete('/:id', authMiddleware, (req, res) => {
 
   db.run('DELETE FROM expenses WHERE id = ? AND user_id = ?', [expenseId, userId], function(err) {
     if (err) {
-      return res.status(500).json({ message: 'Error deleting expense' });
+      return res.status(500).json({ message: 'Error al eliminar el gasto' });
     }
 
     if (this.changes === 0) {
-      return res.status(404).json({ message: 'Expense not found' });
+      return res.status(404).json({ message: 'Gasto no encontrado' });
     }
 
-    res.json({ message: 'Expense deleted successfully' });
+    res.json({ message: 'Gasto eliminado correctamente' });
   });
 });
 
@@ -340,7 +340,7 @@ router.get('/stats/summary', authMiddleware, (req, res) => {
 
   db.all(query, params, (err, categoryStats) => {
     if (err) {
-      return res.status(500).json({ message: 'Database error' });
+      return res.status(500).json({ message: 'Error de base de datos' });
     }
 
     // Get total summary
@@ -367,7 +367,7 @@ router.get('/stats/summary', authMiddleware, (req, res) => {
 
     db.get(totalQuery, totalParams, (err, totalStats) => {
       if (err) {
-        return res.status(500).json({ message: 'Database error' });
+        return res.status(500).json({ message: 'Error de base de datos' });
       }
 
       res.json({

--- a/server/routes/reports.js
+++ b/server/routes/reports.js
@@ -31,7 +31,7 @@ router.post('/generate', authMiddleware, async (req, res) => {
     const result = await pdfService.generateExpenseReport(userId, options);
 
     res.json({
-      message: 'Report generated successfully',
+      message: 'Reporte generado correctamente',
       fileName: result.fileName,
       downloadUrl: `/api/reports/download/${result.fileName}`,
       summary: {
@@ -44,9 +44,9 @@ router.post('/generate', authMiddleware, async (req, res) => {
 
   } catch (error) {
     console.error('Error generating report:', error);
-    res.status(500).json({ 
-      message: 'Error generating report', 
-      error: error.message 
+    res.status(500).json({
+      message: 'Error al generar el reporte',
+      error: error.message
     });
   }
 });
@@ -58,19 +58,19 @@ router.get('/download/:fileName', authMiddleware, (req, res) => {
     
     // Validate filename to prevent directory traversal
     if (!fileName.match(/^expense-report-\d+-\d+\.pdf$/)) {
-      return res.status(400).json({ message: 'Invalid filename' });
+      return res.status(400).json({ message: 'Nombre de archivo inválido' });
     }
 
     const filePath = path.join(__dirname, '../reports', fileName);
 
     if (!fs.existsSync(filePath)) {
-      return res.status(404).json({ message: 'Report not found' });
+      return res.status(404).json({ message: 'Reporte no encontrado' });
     }
 
     // Check if user owns this report (extract user ID from filename)
     const fileUserId = fileName.split('-')[2];
     if (fileUserId !== req.user.id.toString()) {
-      return res.status(403).json({ message: 'Access denied' });
+      return res.status(403).json({ message: 'Acceso denegado' });
     }
 
     res.setHeader('Content-Type', 'application/pdf');
@@ -82,15 +82,15 @@ router.get('/download/:fileName', authMiddleware, (req, res) => {
     fileStream.on('error', (error) => {
       console.error('Error streaming file:', error);
       if (!res.headersSent) {
-        res.status(500).json({ message: 'Error downloading report' });
+        res.status(500).json({ message: 'Error al descargar el reporte' });
       }
     });
 
   } catch (error) {
     console.error('Error downloading report:', error);
-    res.status(500).json({ 
-      message: 'Error downloading report', 
-      error: error.message 
+    res.status(500).json({
+      message: 'Error al descargar el reporte',
+      error: error.message
     });
   }
 });
@@ -101,28 +101,28 @@ router.get('/formats', authMiddleware, (req, res) => {
     formats: [
       {
         value: 'weekly',
-        label: 'Weekly Report',
-        description: 'Last 7 days of expenses'
+        label: 'Reporte semanal',
+        description: 'Últimos 7 días de gastos'
       },
       {
         value: 'monthly',
-        label: 'Monthly Report',
-        description: 'Current or selected month'
+        label: 'Reporte mensual',
+        description: 'Mes actual o seleccionado'
       },
       {
         value: 'quarterly',
-        label: 'Quarterly Report',
-        description: 'Last 3 months of expenses'
+        label: 'Reporte trimestral',
+        description: 'Últimos 3 meses de gastos'
       },
       {
         value: 'yearly',
-        label: 'Yearly Report',
-        description: 'Current or selected year'
+        label: 'Reporte anual',
+        description: 'Año actual o seleccionado'
       },
       {
         value: 'custom',
-        label: 'Custom Range',
-        description: 'Specify start and end dates'
+        label: 'Rango personalizado',
+        description: 'Especifica fecha de inicio y fin'
       }
     ]
   });
@@ -137,32 +137,32 @@ router.get('/templates', authMiddleware, (req, res) => {
   res.json({
     templates: [
       {
-        name: 'This Week',
+        name: 'Esta semana',
         startDate: new Date(now.setDate(now.getDate() - now.getDay())).toISOString().split('T')[0],
         endDate: new Date().toISOString().split('T')[0]
       },
       {
-        name: 'Last Week',
+        name: 'Semana pasada',
         startDate: new Date(now.setDate(now.getDate() - now.getDay() - 7)).toISOString().split('T')[0],
         endDate: new Date(now.setDate(now.getDate() - now.getDay() - 1)).toISOString().split('T')[0]
       },
       {
-        name: 'This Month',
+        name: 'Este mes',
         startDate: new Date(currentYear, currentMonth, 1).toISOString().split('T')[0],
         endDate: new Date().toISOString().split('T')[0]
       },
       {
-        name: 'Last Month',
+        name: 'Mes pasado',
         startDate: new Date(currentYear, currentMonth - 1, 1).toISOString().split('T')[0],
         endDate: new Date(currentYear, currentMonth, 0).toISOString().split('T')[0]
       },
       {
-        name: 'This Year',
+        name: 'Este año',
         startDate: new Date(currentYear, 0, 1).toISOString().split('T')[0],
         endDate: new Date().toISOString().split('T')[0]
       },
       {
-        name: 'Last Year',
+        name: 'Año pasado',
         startDate: new Date(currentYear - 1, 0, 1).toISOString().split('T')[0],
         endDate: new Date(currentYear - 1, 11, 31).toISOString().split('T')[0]
       }
@@ -176,14 +176,14 @@ router.delete('/cleanup', authMiddleware, async (req, res) => {
     const { maxAgeHours = 24 } = req.body;
     await pdfService.cleanupOldReports(maxAgeHours);
     
-    res.json({ 
-      message: 'Old reports cleaned up successfully' 
+    res.json({
+      message: 'Reportes antiguos eliminados correctamente'
     });
   } catch (error) {
     console.error('Error cleaning up reports:', error);
-    res.status(500).json({ 
-      message: 'Error cleaning up reports', 
-      error: error.message 
+    res.status(500).json({
+      message: 'Error al eliminar reportes',
+      error: error.message
     });
   }
 });

--- a/server/services/currencyService.js
+++ b/server/services/currencyService.js
@@ -18,17 +18,17 @@ class CurrencyService {
       this.updateExchangeRates();
     }, 10000);
 
-    console.log('Currency service scheduler initialized');
+    console.log('Programador del servicio de divisas inicializado');
   }
 
   async updateExchangeRates() {
     if (!process.env.EXCHANGE_API_KEY) {
-      console.log('Exchange rate API key not configured, skipping update');
+      console.log('Clave de API de tipo de cambio no configurada, omitiendo actualización');
       return;
     }
 
     try {
-      console.log('Updating exchange rates...');
+      console.log('Actualizando tasas de cambio...');
       
       // Using exchangerate-api.com as primary source
       const response = await axios.get(
@@ -59,14 +59,14 @@ class CurrencyService {
             );
           });
         } catch (error) {
-          console.error(`Error updating rate for ${currencyCode}:`, error);
+          console.error(`Error al actualizar la tasa para ${currencyCode}:`, error);
         }
       }
 
-      console.log(`Exchange rates updated successfully. Updated ${updatedCount} currencies.`);
+      console.log(`Tasas de cambio actualizadas correctamente. ${updatedCount} monedas actualizadas.`);
       
     } catch (error) {
-      console.error('Error updating exchange rates:', error.message);
+      console.error('Error al actualizar las tasas de cambio:', error.message);
       
       // Fallback to fixer.io if primary API fails
       if (process.env.FIXER_API_KEY) {
@@ -77,7 +77,7 @@ class CurrencyService {
 
   async updateExchangeRatesWithFixer() {
     try {
-      console.log('Trying fallback exchange rate service...');
+      console.log('Intentando servicio alternativo de tasas de cambio...');
       
       const response = await axios.get(
         `http://data.fixer.io/api/latest?access_key=${process.env.FIXER_API_KEY}&base=USD`,
@@ -85,7 +85,7 @@ class CurrencyService {
       );
 
       if (!response.data.success) {
-        throw new Error('Fixer.io API returned error');
+        throw new Error('La API de Fixer.io devolvió un error');
       }
 
       const rates = response.data.rates;
@@ -111,14 +111,14 @@ class CurrencyService {
             );
           });
         } catch (error) {
-          console.error(`Error updating rate for ${currencyCode}:`, error);
+          console.error(`Error al actualizar la tasa para ${currencyCode}:`, error);
         }
       }
 
-      console.log(`Fallback exchange rates updated successfully. Updated ${updatedCount} currencies.`);
+      console.log(`Tasas de cambio alternativas actualizadas correctamente. ${updatedCount} monedas actualizadas.`);
       
     } catch (error) {
-      console.error('Fallback exchange rate update also failed:', error.message);
+      console.error('La actualización alternativa de tasas de cambio también falló:', error.message);
     }
   }
 
@@ -141,12 +141,12 @@ class CurrencyService {
         [fromCurrency, toCurrency],
         (err, currencies) => {
           if (err) {
-            reject(new Error('Database error'));
+            reject(new Error('Error de base de datos'));
             return;
           }
 
           if (currencies.length !== 2) {
-            reject(new Error('One or both currencies not found'));
+            reject(new Error('Una o ambas monedas no fueron encontradas'));
             return;
           }
 
@@ -175,12 +175,12 @@ class CurrencyService {
       // Check if currency already exists
       db.get('SELECT id FROM currencies WHERE code = ?', [code], (err, existingCurrency) => {
         if (err) {
-          reject(new Error('Database error'));
+          reject(new Error('Error de base de datos'));
           return;
         }
 
         if (existingCurrency) {
-          reject(new Error('Currency already exists'));
+          reject(new Error('La moneda ya existe'));
           return;
         }
 
@@ -190,14 +190,14 @@ class CurrencyService {
           [code, name, symbol],
           function(err) {
             if (err) {
-              reject(new Error('Error adding currency'));
+              reject(new Error('Error al agregar la moneda'));
               return;
             }
 
             // Get the created currency
             db.get('SELECT * FROM currencies WHERE id = ?', [this.lastID], (err, currency) => {
               if (err) {
-                reject(new Error('Error retrieving created currency'));
+                reject(new Error('Error al obtener la moneda creada'));
                 return;
               }
 
@@ -213,7 +213,7 @@ class CurrencyService {
     return new Promise((resolve, reject) => {
       db.all('SELECT * FROM currencies ORDER BY code ASC', (err, currencies) => {
         if (err) {
-          reject(new Error('Database error'));
+          reject(new Error('Error de base de datos'));
           return;
         }
 
@@ -240,7 +240,7 @@ class CurrencyService {
 
       db.all(query, [userId], (err, stats) => {
         if (err) {
-          reject(new Error('Database error'));
+          reject(new Error('Error de base de datos'));
           return;
         }
 
@@ -258,12 +258,12 @@ class CurrencyService {
         [currencyCode],
         (err, currency) => {
           if (err) {
-            reject(new Error('Database error'));
+            reject(new Error('Error de base de datos'));
             return;
           }
 
           if (!currency) {
-            reject(new Error('Currency not found'));
+            reject(new Error('Moneda no encontrada'));
             return;
           }
 
@@ -295,7 +295,7 @@ class CurrencyService {
 
       db.all(query, [limit], (err, currencies) => {
         if (err) {
-          reject(new Error('Database error'));
+          reject(new Error('Error de base de datos'));
           return;
         }
 

--- a/server/services/pdfService.js
+++ b/server/services/pdfService.js
@@ -26,7 +26,7 @@ class PDFService {
       // Get user info
       db.get('SELECT * FROM users WHERE id = ?', [userId], async (err, user) => {
         if (err || !user) {
-          reject(new Error('User not found'));
+          reject(new Error('Usuario no encontrado'));
           return;
         }
 


### PR DESCRIPTION
## Summary
- Localized client pages and components to Spanish, replacing labels, errors and placeholders.
- Updated API responses across auth, expenses, categories, currencies and reports routes to return messages in Spanish.
- Translated server service messages for consistent Spanish error handling.

## Testing
- `npm test -- --watchAll=false` *(client: no tests found)*
- `npm test` *(server: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68a39bfeecbc8328be56d00e80678325