### PR TITLE
Fix sidebar responsive class

### DIFF
--- a/client/src/components/Layout.tsx
+++ b/client/src/components/Layout.tsx
@@ -37,10 +37,9 @@ const Layout: React.FC = () => {
       )}
 
       {/* Sidebar */}
-      <div className={`
-        fixed inset-y-0 left-0 z-30 w-64 bg-white shadow-lg transform transition-transform duration-300 ease-in-out lg:translate-x-0 lg:static lg:inset-0
-        ${sidebarOpen ? 'translate-x-0' : '-translate-x-full'}
-      `}>
+        <div
+          className={`fixed inset-y-0 left-0 z-30 w-64 bg-white shadow-lg transform transition-transform duration-300 ease-in-out lg:translate-x-0 lg:static lg:inset-0 ${sidebarOpen ? 'translate-x-0' : '-translate-x-full'}`}
+        >
         <div className="flex items-center justify-between h-16 px-4 border-b border-gray-200">
           <h1 className="text-lg lg:text-xl font-bold text-gray-900 truncate">Gastos Robert</h1>
           <button


### PR DESCRIPTION
## Summary
- ensure sidebar container keeps visible on lg screens

## Testing
- `npm --prefix client test -- --watchAll=false --passWithNoTests`
- used Playwright to confirm sidebar at large viewport: `sidebar box { x: 0, y: 0, width: 256, height: 296 }`


------
https://chatgpt.com/codex/tasks/task_e_68a3ccbe50588328894e6cb2f584d25c