### PR TITLE
Add description filter and reports page with export

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -14,6 +14,7 @@ import Dashboard from './pages/Dashboard';
 import Expenses from './pages/Expenses';
 import Categories from './pages/Categories';
 import Profile from './pages/Profile';
+import Reports from './pages/Reports';
 
 const ProtectedRoute: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const { user, loading } = useAuth();
@@ -67,6 +68,7 @@ const AppRoutes: React.FC = () => {
           <Route path="dashboard" element={<Dashboard />} />
           <Route path="expenses" element={<Expenses />} />
           <Route path="categories" element={<Categories />} />
+          <Route path="reports" element={<Reports />} />
           <Route path="profile" element={<Profile />} />
         </Route>
         <Route path="*" element={<Navigate to="/" />} />

--- a/client/src/components/Layout.tsx
+++ b/client/src/components/Layout.tsx
@@ -3,11 +3,12 @@ import { Outlet, Link, useLocation } from 'react-router-dom';
 import { 
   FiHome, 
   FiDollarSign, 
-  FiTag, 
-  FiUser, 
-  FiMenu, 
+  FiTag,
+  FiUser,
+  FiFileText,
+  FiMenu,
   FiX,
-  FiLogOut 
+  FiLogOut
 } from 'react-icons/fi';
 import { useAuth } from '../contexts/AuthContext';
 import { getInitials } from '../utils/format';
@@ -21,6 +22,7 @@ const Layout: React.FC = () => {
     { name: 'Inicio', href: '/dashboard', icon: FiHome },
     { name: 'Gastos', href: '/expenses', icon: FiDollarSign },
     { name: 'Categorías', href: '/categories', icon: FiTag },
+    { name: 'Reportes', href: '/reports', icon: FiFileText },
     { name: 'Perfil', href: '/profile', icon: FiUser },
   ];
 

--- a/client/src/pages/Reports.tsx
+++ b/client/src/pages/Reports.tsx
@@ -1,0 +1,181 @@
+import React, { useState, useEffect } from 'react';
+import { FiDownload, FiFileText } from 'react-icons/fi';
+import api from '../utils/api';
+
+interface Category {
+  id: number;
+  name: string;
+}
+
+interface Summary {
+  totalExpenses: number;
+  totalAmount: number;
+  period: string;
+  generatedAt: string;
+}
+
+const Reports: React.FC = () => {
+  const [categories, setCategories] = useState<Category[]>([]);
+  const [categoryId, setCategoryId] = useState('');
+  const [startDate, setStartDate] = useState('');
+  const [endDate, setEndDate] = useState('');
+  const [search, setSearch] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [downloadUrl, setDownloadUrl] = useState('');
+  const [summary, setSummary] = useState<Summary | null>(null);
+
+  useEffect(() => {
+    const loadCategories = async () => {
+      try {
+        const res = await api.get('/categories');
+        setCategories(res.data);
+      } catch (error) {
+        console.error('Error loading categories:', error);
+      }
+    };
+    loadCategories();
+  }, []);
+
+  const handleGenerate = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+    setDownloadUrl('');
+    setSummary(null);
+    try {
+      const payload: any = {
+        ...(startDate && { startDate }),
+        ...(endDate && { endDate }),
+        ...(categoryId && { categoryId: parseInt(categoryId) }),
+        ...(search && { search }),
+      };
+      const res = await api.post('/reports/generate', payload);
+      setDownloadUrl(res.data.downloadUrl);
+      setSummary(res.data.summary);
+    } catch (error) {
+      console.error('Error generating report:', error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleExportCSV = async () => {
+    try {
+      const params = new URLSearchParams({
+        page: '1',
+        limit: '1000',
+        ...(categoryId && { category: categoryId }),
+        ...(startDate && { startDate }),
+        ...(endDate && { endDate }),
+        ...(search && { search }),
+      });
+      const res = await api.get(`/expenses?${params.toString()}`);
+      const rows = res.data.expenses;
+      const header = ['Date', 'Description', 'Category', 'Amount', 'Currency'];
+      const csv = [
+        header.join(','),
+        ...rows.map((r: any) => [
+          r.date,
+          r.description,
+          r.category_name,
+          r.amount,
+          r.currency_code,
+        ].map((val: any) => `"${String(val).replace(/"/g, '""')}"`).join(','))
+      ].join('\n');
+      const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+      const url = window.URL.createObjectURL(blob);
+      const link = document.createElement('a');
+      link.href = url;
+      link.setAttribute('download', 'expenses.csv');
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+    } catch (error) {
+      console.error('Error exporting CSV:', error);
+    }
+  };
+
+  return (
+    <div>
+      <h1 className="text-2xl font-bold mb-4">Reportes</h1>
+      <form onSubmit={handleGenerate} className="space-y-4 mb-6">
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Categoría</label>
+            <select
+              value={categoryId}
+              onChange={(e) => setCategoryId(e.target.value)}
+              className="input-field"
+            >
+              <option value="">Todas</option>
+              {categories.map((cat) => (
+                <option key={cat.id} value={cat.id}>
+                  {cat.name}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Buscar descripción</label>
+            <input
+              type="text"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              className="input-field"
+              placeholder="Ej: supermercado"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Fecha inicio</label>
+            <input
+              type="date"
+              value={startDate}
+              onChange={(e) => setStartDate(e.target.value)}
+              className="input-field"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Fecha fin</label>
+            <input
+              type="date"
+              value={endDate}
+              onChange={(e) => setEndDate(e.target.value)}
+              className="input-field"
+            />
+          </div>
+        </div>
+        <button type="submit" className="btn-primary" disabled={loading}>
+          {loading ? 'Generando...' : 'Generar reporte'}
+        </button>
+      </form>
+
+      {downloadUrl && (
+        <div className="space-y-2">
+          <a
+            href={downloadUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="btn-secondary inline-flex items-center"
+          >
+            <FiDownload className="mr-2" /> Descargar PDF
+          </a>
+          <button
+            onClick={handleExportCSV}
+            className="btn-secondary inline-flex items-center"
+          >
+            <FiFileText className="mr-2" /> Exportar CSV
+          </button>
+        </div>
+      )}
+
+      {summary && (
+        <div className="mt-6 card">
+          <h2 className="text-lg font-semibold mb-2">Resumen</h2>
+          <p>Total de gastos: {summary.totalExpenses}</p>
+          <p>Monto total: {summary.totalAmount}</p>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default Reports;

--- a/server/routes/reports.js
+++ b/server/routes/reports.js
@@ -14,6 +14,7 @@ router.post('/generate', authMiddleware, async (req, res) => {
       startDate,
       endDate,
       categoryId,
+      search,
       format = 'monthly',
       includeSummary = true,
       includeCharts = true
@@ -23,6 +24,7 @@ router.post('/generate', authMiddleware, async (req, res) => {
       startDate,
       endDate,
       categoryId,
+      search,
       format,
       includeSummary,
       includeCharts

--- a/server/services/pdfService.js
+++ b/server/services/pdfService.js
@@ -50,8 +50,8 @@ class PDFService {
   }
 
   async getReportData(userId, options) {
-    const { startDate, endDate, categoryId } = options;
-    
+    const { startDate, endDate, categoryId, search } = options;
+
     let whereClause = 'WHERE e.user_id = ?';
     let params = [userId];
 
@@ -68,6 +68,11 @@ class PDFService {
     if (categoryId) {
       whereClause += ' AND e.category_id = ?';
       params.push(categoryId);
+    }
+
+    if (search) {
+      whereClause += ' AND e.description LIKE ?';
+      params.push(`%${search}%`);
     }
 
     // Get expenses


### PR DESCRIPTION
## Summary
- allow filtering reports by expense description
- add Reports page with category/date/search filters and PDF/CSV export
- integrate Reports page into app navigation

## Testing
- `cd client && npm test -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68a3d028a950832892da6ae58dc5203d