### PR TITLE
feat: add TRY and NGN currencies

### DIFF
--- a/server/database.js
+++ b/server/database.js
@@ -107,7 +107,9 @@ db.serialize(() => {
     ['CAD', 'Dólar Canadiense', 'C$'],
     ['GBP', 'Libra Esterlina', '£'],
     ['JPY', 'Yen Japonés', '¥'],
-    ['MXN', 'Peso Mexicano', '$']
+    ['MXN', 'Peso Mexicano', '$'],
+    ['TRY', 'Lira Turca', '₺'],
+    ['NGN', 'Naira Nigeriana', '₦']
   ];
 
   const insertCurrency = db.prepare(`


### PR DESCRIPTION
## Summary
- add Turkish lira and Nigerian naira to default currencies

## Testing
- `node server/database.js`
- `curl -s -H "Authorization: Bearer $TOKEN" http://localhost:5000/api/currencies`
- `curl -s -X POST http://localhost:5000/api/expenses -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" -d '{"categoryId":1,"currencyId":8,"amount":100,"description":"Test TRY expense","date":"2025-01-01"}'`
- `npm test` (fails: Missing script: "test")

------
https://chatgpt.com/codex/tasks/task_e_68a3d22fabc48328a89b2ee33ad68617