### PR TITLE
Add COP conversion fields to expenses

### DIFF
--- a/server/database.js
+++ b/server/database.js
@@ -72,6 +72,8 @@ db.serialize(() => {
       category_id INTEGER NOT NULL,
       currency_id INTEGER NOT NULL,
       amount DECIMAL(10,2) NOT NULL,
+      amount_cop DECIMAL(10,2),
+      exchange_rate_cop DECIMAL(10,6),
       description TEXT,
       date DATE NOT NULL,
       is_recurring BOOLEAN DEFAULT FALSE,


### PR DESCRIPTION
## Summary
- track COP equivalents and exchange rates for expenses
- convert and persist COP amounts on create/update
- display COP values and conversion rate in expenses UI

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm --prefix client test -- --watchAll=false` *(fails: No tests found)*
- `npm --prefix client run build`
- `npm --prefix server test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a3d3c516f48328b60aa65812f06579