### PR TITLE
Add payment cycle preferences and recurring expense forecasts

### DIFF
--- a/client/src/contexts/AuthContext.tsx
+++ b/client/src/contexts/AuthContext.tsx
@@ -33,7 +33,9 @@ const parseUserSafely = (userStr: string): User | null => {
       email: parsed.email.trim().toLowerCase(),
       created_at: parsed.created_at || null,
       updated_at: parsed.updated_at || null,
-      reportEmailsEnabled: !!parsed.reportEmailsEnabled
+      reportEmailsEnabled: !!parsed.reportEmailsEnabled,
+      paymentCycle: ['weekly', 'biweekly', 'monthly'].includes(parsed.paymentCycle) ? parsed.paymentCycle : undefined,
+      reminderDaysBefore: typeof parsed.reminderDaysBefore === 'number' ? parsed.reminderDaysBefore : undefined
     };
   } catch (error) {
     console.error('Failed to parse stored user data:', error);
@@ -131,7 +133,9 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
         email: newUser.email?.trim().toLowerCase() || '',
         created_at: newUser.created_at || null,
         updated_at: newUser.updated_at || null,
-        reportEmailsEnabled: !!newUser.reportEmailsEnabled
+        reportEmailsEnabled: !!newUser.reportEmailsEnabled,
+        paymentCycle: ['weekly', 'biweekly', 'monthly'].includes(newUser.paymentCycle) ? newUser.paymentCycle : undefined,
+        reminderDaysBefore: typeof newUser.reminderDaysBefore === 'number' ? newUser.reminderDaysBefore : undefined
       };
 
       setToken(newToken);
@@ -169,7 +173,9 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
         email: newUser.email?.trim().toLowerCase() || '',
         created_at: newUser.created_at || null,
         updated_at: newUser.updated_at || null,
-        reportEmailsEnabled: !!newUser.reportEmailsEnabled
+        reportEmailsEnabled: !!newUser.reportEmailsEnabled,
+        paymentCycle: ['weekly', 'biweekly', 'monthly'].includes(newUser.paymentCycle) ? newUser.paymentCycle : undefined,
+        reminderDaysBefore: typeof newUser.reminderDaysBefore === 'number' ? newUser.reminderDaysBefore : undefined
       };
 
       setToken(newToken);

--- a/client/src/pages/Profile.tsx
+++ b/client/src/pages/Profile.tsx
@@ -15,7 +15,9 @@ const Profile: React.FC = () => {
   const [profileForm, setProfileForm] = useState({
     username: user?.username || '',
     email: user?.email || '',
-    reportEmailsEnabled: user?.reportEmailsEnabled ?? false
+    reportEmailsEnabled: user?.reportEmailsEnabled ?? false,
+    paymentCycle: user?.paymentCycle || 'monthly',
+    reminderDaysBefore: user?.reminderDaysBefore ?? 3
   });
 
   // Password form state
@@ -47,6 +49,14 @@ const Profile: React.FC = () => {
       newErrors.email = 'Por favor ingresa un correo electrónico válido';
     } else if (profileForm.email.length > 254) {
       newErrors.email = 'El correo electrónico es demasiado largo';
+    }
+
+    if (!['weekly', 'biweekly', 'monthly'].includes(profileForm.paymentCycle)) {
+      newErrors.paymentCycle = 'Selecciona un ciclo de pago válido';
+    }
+
+    if (profileForm.reminderDaysBefore < 0) {
+      newErrors.reminderDaysBefore = 'Debe ser un número positivo';
     }
 
     return newErrors;
@@ -100,7 +110,9 @@ const Profile: React.FC = () => {
       const response = await api.put('/auth/profile', {
         username: profileForm.username.trim(),
         email: profileForm.email.trim().toLowerCase(),
-        reportEmailsEnabled: profileForm.reportEmailsEnabled
+        reportEmailsEnabled: profileForm.reportEmailsEnabled,
+        paymentCycle: profileForm.paymentCycle,
+        reminderDaysBefore: profileForm.reminderDaysBefore
       });
 
       setSuccessMessage('Perfil actualizado correctamente');
@@ -251,6 +263,46 @@ const Profile: React.FC = () => {
                 <label className="ml-2 block text-sm text-gray-700">
                   Recibir reportes por correo
                 </label>
+              </div>
+
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  Ciclo de pago
+                </label>
+                <select
+                  value={profileForm.paymentCycle}
+                  onChange={(e) => {
+                    setProfileForm(prev => ({ ...prev, paymentCycle: e.target.value }));
+                    clearMessages();
+                  }}
+                  className="input-field"
+                >
+                  <option value="weekly">Semanal</option>
+                  <option value="biweekly">Quincenal</option>
+                  <option value="monthly">Mensual</option>
+                </select>
+                {errors.paymentCycle && (
+                  <p className="mt-1 text-sm text-red-600">{errors.paymentCycle}</p>
+                )}
+              </div>
+
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  Recordatorio (días antes)
+                </label>
+                <input
+                  type="number"
+                  min={0}
+                  value={profileForm.reminderDaysBefore}
+                  onChange={(e) => {
+                    setProfileForm(prev => ({ ...prev, reminderDaysBefore: parseInt(e.target.value, 10) || 0 }));
+                    clearMessages();
+                  }}
+                  className={`input-field ${errors.reminderDaysBefore ? 'border-red-300' : ''}`}
+                />
+                {errors.reminderDaysBefore && (
+                  <p className="mt-1 text-sm text-red-600">{errors.reminderDaysBefore}</p>
+                )}
               </div>
 
               <div className="pt-4">

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -5,6 +5,8 @@ export interface User {
   created_at?: string | null;
   updated_at?: string | null;
   reportEmailsEnabled?: boolean;
+  paymentCycle?: 'weekly' | 'biweekly' | 'monthly';
+  reminderDaysBefore?: number;
 }
 
 export interface Category {

--- a/scripts/migrate-user-preferences.js
+++ b/scripts/migrate-user-preferences.js
@@ -1,0 +1,33 @@
+const sqlite3 = require('sqlite3').verbose();
+const path = require('path');
+
+const dbPath = process.env.DB_PATH || path.join(__dirname, '..', 'server', 'gastos_robert.db');
+const db = new sqlite3.Database(dbPath);
+
+function ensureColumn(table, column, definition) {
+  db.all(`PRAGMA table_info(${table})`, (err, columns) => {
+    if (err) {
+      console.error('Error inspeccionando tabla', table, err);
+      return;
+    }
+    if (!columns.some(col => col.name === column)) {
+      db.run(`ALTER TABLE ${table} ADD COLUMN ${column} ${definition}`, (alterErr) => {
+        if (alterErr) {
+          console.error(`Error agregando columna ${column}:`, alterErr);
+        } else {
+          console.log(`Columna ${column} agregada a ${table}`);
+        }
+      });
+    } else {
+      console.log(`Columna ${column} ya existe en ${table}`);
+    }
+  });
+}
+
+db.serialize(() => {
+  ensureColumn('users', 'payment_cycle', "VARCHAR(20) DEFAULT 'monthly'");
+  ensureColumn('users', 'reminder_days_before', 'INTEGER DEFAULT 3');
+});
+
+db.close();
+console.log('Migración completada');

--- a/server/database.js
+++ b/server/database.js
@@ -36,7 +36,9 @@ db.serialize(() => {
       password_hash VARCHAR(255) NOT NULL,
       created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
       updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-      report_emails_enabled BOOLEAN DEFAULT 0
+      report_emails_enabled BOOLEAN DEFAULT 0,
+      payment_cycle VARCHAR(20) DEFAULT 'monthly',
+      reminder_days_before INTEGER DEFAULT 3
     )
   `);
 
@@ -44,12 +46,30 @@ db.serialize(() => {
   db.all("PRAGMA table_info(users)", (err, columns) => {
     if (err) {
       console.error('Error inspeccionando tabla users:', err);
-    } else if (!columns.some(col => col.name === 'report_emails_enabled')) {
-      db.run('ALTER TABLE users ADD COLUMN report_emails_enabled BOOLEAN DEFAULT 0', alterErr => {
-        if (alterErr) {
-          console.error('Error agregando report_emails_enabled:', alterErr);
-        }
-      });
+    } else {
+      if (!columns.some(col => col.name === 'report_emails_enabled')) {
+        db.run('ALTER TABLE users ADD COLUMN report_emails_enabled BOOLEAN DEFAULT 0', alterErr => {
+          if (alterErr) {
+            console.error('Error agregando report_emails_enabled:', alterErr);
+          }
+        });
+      }
+
+      if (!columns.some(col => col.name === 'payment_cycle')) {
+        db.run("ALTER TABLE users ADD COLUMN payment_cycle VARCHAR(20) DEFAULT 'monthly'", alterErr => {
+          if (alterErr) {
+            console.error('Error agregando payment_cycle:', alterErr);
+          }
+        });
+      }
+
+      if (!columns.some(col => col.name === 'reminder_days_before')) {
+        db.run('ALTER TABLE users ADD COLUMN reminder_days_before INTEGER DEFAULT 3', alterErr => {
+          if (alterErr) {
+            console.error('Error agregando reminder_days_before:', alterErr);
+          }
+        });
+      }
     }
   });
 

--- a/server/middleware/auth.js
+++ b/server/middleware/auth.js
@@ -37,7 +37,7 @@ const authMiddleware = async (req, res, next) => {
     // Verificar que el usuario aún exista en la base de datos
     let user;
     try {
-      user = await dbGet('SELECT id, username, email, created_at, report_emails_enabled FROM users WHERE id = ?', [decoded.userId]);
+      user = await dbGet('SELECT id, username, email, created_at, updated_at, report_emails_enabled, payment_cycle, reminder_days_before FROM users WHERE id = ?', [decoded.userId]);
     } catch (dbError) {
       console.error('Error de base de datos durante autenticación:', dbError);
       return res.status(500).json({ message: 'Servicio de autenticación temporalmente no disponible.' });
@@ -54,7 +54,10 @@ const authMiddleware = async (req, res, next) => {
       username: user.username,
       email: user.email,
       created_at: user.created_at,
-      reportEmailsEnabled: !!user.report_emails_enabled
+      updated_at: user.updated_at,
+      reportEmailsEnabled: !!user.report_emails_enabled,
+      paymentCycle: user.payment_cycle,
+      reminderDaysBefore: user.reminder_days_before
     };
 
     // Agregar información de token para funcionalidad potencial de logout/blacklist

--- a/server/routes/reports.js
+++ b/server/routes/reports.js
@@ -3,6 +3,7 @@ const path = require('path');
 const fs = require('fs');
 const authMiddleware = require('../middleware/auth');
 const pdfService = require('../services/pdfService');
+const emailService = require('../services/emailService');
 
 const router = express.Router();
 
@@ -50,6 +51,19 @@ router.post('/generate', authMiddleware, async (req, res) => {
       message: 'Error al generar el reporte',
       error: error.message
     });
+  }
+});
+
+// Send recurring expense forecast for next cycle
+router.post('/recurring-forecast', authMiddleware, async (req, res) => {
+  try {
+    const user = req.user;
+    const { start, end } = emailService.getNextCycleRange(user.paymentCycle);
+    await emailService.sendRecurringForecast(user, start, end);
+    res.json({ message: 'Reporte enviado correctamente' });
+  } catch (error) {
+    console.error('Error sending recurring forecast:', error);
+    res.status(500).json({ message: 'Error al enviar el reporte', error: error.message });
   }
 });
 


### PR DESCRIPTION
## Summary
- add `payment_cycle` and `reminder_days_before` columns to users
- allow auth/profile routes and client to manage new user preferences
- email service forecasts recurring expenses per payment cycle with manual trigger and cron

## Testing
- `cd server && npm test` *(fails: Missing script: "test")*
- `cd client && npm test -- --watchAll=false` *(fails: No tests found, exiting with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68a3df98c3308328961fba137a446c2c