### PR TITLE
Add test email endpoint and profile trigger

### DIFF
--- a/client/src/pages/Profile.tsx
+++ b/client/src/pages/Profile.tsx
@@ -7,6 +7,7 @@ import api from '../utils/api';
 const Profile: React.FC = () => {
   const { user } = useAuth();
   const [loading, setLoading] = useState(false);
+  const [testEmailLoading, setTestEmailLoading] = useState(false);
   const [showCurrentPassword, setShowCurrentPassword] = useState(false);
   const [showNewPassword, setShowNewPassword] = useState(false);
   const [showConfirmPassword, setShowConfirmPassword] = useState(false);
@@ -166,6 +167,21 @@ const Profile: React.FC = () => {
     }
   };
 
+  const handleSendTestEmail = async () => {
+    setErrors({});
+    setSuccessMessage('');
+    try {
+      setTestEmailLoading(true);
+      await api.post('/email/test');
+      setSuccessMessage('Correo de prueba enviado correctamente');
+    } catch (error: any) {
+      console.error('Error al enviar el correo de prueba:', error);
+      setErrors({ emailTest: error.response?.data?.message || 'Error al enviar el correo de prueba' });
+    } finally {
+      setTestEmailLoading(false);
+    }
+  };
+
   const clearMessages = () => {
     setErrors({});
     setSuccessMessage('');
@@ -193,6 +209,32 @@ const Profile: React.FC = () => {
           {successMessage}
         </div>
       )}
+
+      {errors.emailTest && (
+        <div className="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded-lg">
+          {errors.emailTest}
+        </div>
+      )}
+
+      <div className="flex justify-end">
+        <button
+          onClick={handleSendTestEmail}
+          disabled={testEmailLoading}
+          className="btn-secondary inline-flex items-center"
+        >
+          {testEmailLoading ? (
+            <>
+              <LoadingSpinner size="sm" />
+              <span className="ml-2">Enviando...</span>
+            </>
+          ) : (
+            <>
+              <FiMail className="w-4 h-4 mr-2" />
+              Enviar correo de prueba
+            </>
+          )}
+        </button>
+      </div>
 
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         {/* Profile Information */}

--- a/server/index.js
+++ b/server/index.js
@@ -21,6 +21,7 @@ const expenseRoutes = require('./routes/expenses');
 const categoryRoutes = require('./routes/categories');
 const currencyRoutes = require('./routes/currencies');
 const reportRoutes = require('./routes/reports');
+const emailRoutes = require('./routes/email');
 
 const app = express();
 // Permitir que Express confíe en el proxy (Nginx) para X-Forwarded-For
@@ -124,6 +125,7 @@ app.use('/api/expenses', expenseRoutes);
 app.use('/api/categories', categoryRoutes);
 app.use('/api/currencies', currencyRoutes);
 app.use('/api/reports', reportRoutes);
+app.use('/api/email', emailRoutes);
 
 // Endpoint de verificación de salud
 app.get('/api/health', (req, res) => {

--- a/server/routes/email.js
+++ b/server/routes/email.js
@@ -1,0 +1,18 @@
+const express = require('express');
+const authMiddleware = require('../middleware/auth');
+const emailService = require('../services/emailService');
+
+const router = express.Router();
+
+router.post('/test', authMiddleware, async (req, res) => {
+  try {
+    const user = req.user;
+    await emailService.sendTestEmail(user);
+    res.json({ message: 'Correo de prueba enviado correctamente' });
+  } catch (error) {
+    console.error('Error sending test email:', error);
+    res.status(500).json({ message: 'Error al enviar el correo de prueba', error: error.message });
+  }
+});
+
+module.exports = router;

--- a/server/services/emailService.js
+++ b/server/services/emailService.js
@@ -60,6 +60,13 @@ class EmailService {
     }
   }
 
+  async sendTestEmail(user) {
+    const subject = 'Test Email';
+    const html = `<p>Hola ${user.username || ''}, este es un correo de prueba.</p>`;
+    const text = `Hola ${user.username || ''}, este es un correo de prueba.`;
+    return this.sendEmail(user.email, subject, html, text);
+  }
+
   async sendExpenseReminder(user, expense) {
     const subject = `Reminder: ${expense.description} due soon`;
     


### PR DESCRIPTION
## Summary
- support sending simple test email via `sendTestEmail`
- expose `/api/email/test` route protected by auth
- add profile page button to trigger test email

## Testing
- `cd server && npm test` *(fails: Missing script "test"*)
- `cd client && npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68a3e1b75320832880a3776ab8554c0e