### PR TITLE
feat: add configurable expense reminder days

### DIFF
--- a/client/src/pages/Expenses.tsx
+++ b/client/src/pages/Expenses.tsx
@@ -15,6 +15,7 @@ interface Expense {
   is_recurring: boolean;
   recurring_frequency?: string;
   next_due_date?: string;
+  reminder_days_before?: number;
   category_id: number;
   category_name: string;
   category_color: string;
@@ -60,7 +61,8 @@ const Expenses: React.FC = () => {
     categoryId: '',
     currencyId: '',
     is_recurring: false,
-    recurring_frequency: 'monthly'
+    recurring_frequency: 'monthly',
+    reminder_days_before: 1
   });
 
   const [errors, setErrors] = useState<Record<string, string>>({});
@@ -189,6 +191,7 @@ const Expenses: React.FC = () => {
       data.append('currencyId', formData.currencyId);
       data.append('isRecurring', String(formData.is_recurring));
       data.append('recurringFrequency', formData.recurring_frequency);
+      data.append('reminderDaysBefore', formData.reminder_days_before.toString());
       if (attachment) {
         data.append('attachment', attachment);
       }
@@ -220,7 +223,8 @@ const Expenses: React.FC = () => {
       categoryId: expense.category_id?.toString() || '',
       currencyId: expense.currency_id?.toString() || '',
       is_recurring: expense.is_recurring,
-      recurring_frequency: expense.recurring_frequency || 'monthly'
+      recurring_frequency: expense.recurring_frequency || 'monthly',
+      reminder_days_before: expense.reminder_days_before || 1
     });
     setCopEquivalent(expense.amount_cop ? expense.amount_cop.toString() : '');
     setExchangeRateCop(expense.exchange_rate_cop || null);
@@ -249,7 +253,8 @@ const Expenses: React.FC = () => {
       categoryId: '',
       currencyId: currencies.length > 0 ? currencies[0].id.toString() : '',
       is_recurring: false,
-      recurring_frequency: 'monthly'
+      recurring_frequency: 'monthly',
+      reminder_days_before: 1
     });
     setErrors({});
     setCopEquivalent('');
@@ -659,21 +664,38 @@ const Expenses: React.FC = () => {
                 </div>
 
                 {formData.is_recurring && (
-                  <div>
-                    <label className="block text-sm font-medium text-gray-700 mb-1">
-                      Frecuencia
-                    </label>
-                    <select
-                      value={formData.recurring_frequency}
-                      onChange={(e) => setFormData(prev => ({ ...prev, recurring_frequency: e.target.value }))}
-                      className="input-field"
-                    >
-                      <option value="daily">Diaria</option>
-                      <option value="weekly">Semanal</option>
-                      <option value="monthly">Mensual</option>
-                      <option value="yearly">Anual</option>
-                    </select>
-                  </div>
+                  <>
+                    <div>
+                      <label className="block text-sm font-medium text-gray-700 mb-1">
+                        Frecuencia
+                      </label>
+                      <select
+                        value={formData.recurring_frequency}
+                        onChange={(e) => setFormData(prev => ({ ...prev, recurring_frequency: e.target.value }))}
+                        className="input-field"
+                      >
+                        <option value="daily">Diaria</option>
+                        <option value="weekly">Semanal</option>
+                        <option value="monthly">Mensual</option>
+                        <option value="yearly">Anual</option>
+                      </select>
+                    </div>
+
+                    <div>
+                      <label className="block text-sm font-medium text-gray-700 mb-1">
+                        Recordar (días antes)
+                      </label>
+                      <select
+                        value={formData.reminder_days_before}
+                        onChange={(e) => setFormData(prev => ({ ...prev, reminder_days_before: parseInt(e.target.value) }))}
+                        className="input-field"
+                      >
+                        <option value={1}>1</option>
+                        <option value={2}>2</option>
+                        <option value={3}>3</option>
+                      </select>
+                    </div>
+                  </>
                 )}
 
                 <div className="flex space-x-3 pt-4">

--- a/server/database.js
+++ b/server/database.js
@@ -113,6 +113,7 @@ db.serialize(() => {
       is_recurring BOOLEAN DEFAULT FALSE,
       recurring_frequency VARCHAR(20),
       next_due_date DATE,
+      reminder_days_before INTEGER DEFAULT 1,
       attachment_path TEXT,
       created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
       updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
@@ -122,16 +123,26 @@ db.serialize(() => {
     )
   `);
 
-  // Ensure attachment_path column exists for older databases
+  // Ensure new columns exist for older databases
   db.all("PRAGMA table_info(expenses)", (err, columns) => {
     if (err) {
       console.error('Error inspeccionando tabla expenses:', err);
-    } else if (!columns.some(col => col.name === 'attachment_path')) {
-      db.run('ALTER TABLE expenses ADD COLUMN attachment_path TEXT', alterErr => {
-        if (alterErr) {
-          console.error('Error agregando attachment_path:', alterErr);
-        }
-      });
+    } else {
+      if (!columns.some(col => col.name === 'attachment_path')) {
+        db.run('ALTER TABLE expenses ADD COLUMN attachment_path TEXT', alterErr => {
+          if (alterErr) {
+            console.error('Error agregando attachment_path:', alterErr);
+          }
+        });
+      }
+
+      if (!columns.some(col => col.name === 'reminder_days_before')) {
+        db.run('ALTER TABLE expenses ADD COLUMN reminder_days_before INTEGER DEFAULT 1', alterErr => {
+          if (alterErr) {
+            console.error('Error agregando reminder_days_before:', alterErr);
+          }
+        });
+      }
     }
   });
 

--- a/server/services/emailService.js
+++ b/server/services/emailService.js
@@ -350,26 +350,25 @@ class EmailService {
 
     try {
       const today = new Date().toISOString().split('T')[0];
-      const tomorrow = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString().split('T')[0];
 
-      // Get recurring expenses due today or tomorrow
+      // Get recurring expenses whose reminder should be sent today
       const query = `
         SELECT e.*, u.username, u.email, c.name as category_name, cur.symbol as currency_symbol
         FROM expenses e
         JOIN users u ON e.user_id = u.id
         JOIN categories c ON e.category_id = c.id
         JOIN currencies cur ON e.currency_id = cur.id
-        WHERE e.is_recurring = 1 
-        AND e.next_due_date IN (?, ?)
+        WHERE e.is_recurring = 1
+        AND date(e.next_due_date, '-' || IFNULL(e.reminder_days_before, 1) || ' day') = ?
         AND NOT EXISTS (
-          SELECT 1 FROM email_reminders er 
-          WHERE er.expense_id = e.id 
-          AND er.reminder_date = ? 
+          SELECT 1 FROM email_reminders er
+          WHERE er.expense_id = e.id
+          AND er.reminder_date = date(e.next_due_date, '-' || IFNULL(e.reminder_days_before, 1) || ' day')
           AND er.is_sent = 1
         )
       `;
 
-      db.all(query, [today, tomorrow, today], async (err, expenses) => {
+      db.all(query, [today], async (err, expenses) => {
         if (err) {
           console.error('Error fetching reminder expenses:', err);
           return;
@@ -382,10 +381,14 @@ class EmailService {
               expense
             );
 
+            const reminderDate = new Date(new Date(expense.next_due_date).getTime() - (expense.reminder_days_before || 1) * 24 * 60 * 60 * 1000)
+              .toISOString()
+              .split('T')[0];
+
             // Mark reminder as sent
             db.run(
               'INSERT INTO email_reminders (user_id, expense_id, reminder_date, is_sent) VALUES (?, ?, ?, 1)',
-              [expense.user_id, expense.id, today]
+              [expense.user_id, expense.id, reminderDate]
             );
 
             console.log(`Reminder sent for expense ${expense.id} to ${expense.email}`);


### PR DESCRIPTION
## Summary
- add `reminder_days_before` column to expenses with migration support
- allow API and client to set reminder days before recurring expenses
- adjust email reminder scheduler to honor per-expense reminder lead time

## Testing
- `npm test` *(fails: Missing script: "test")*
- `cd client && npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68a3e2cbc11483288a9289284d23fe83