### PR TITLE
Increase auth rate limiter to 10 requests

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -65,7 +65,7 @@ app.use('/api/', limiter);
 // Limitación más estricta para endpoints de autenticación
 const authLimiter = rateLimit({
   windowMs: 15 * 60 * 1000, // 15 minutos
-  max: 5, // limitar cada IP a 5 requests por ventana para auth
+  max: 10, // limitar cada IP a 10 requests por ventana para auth
   message: 'Demasiados intentos de autenticación, intente de nuevo más tarde.'
 });
 app.use('/api/auth/login', authLimiter);


### PR DESCRIPTION
## Summary
- Allow up to 10 authentication attempts per 15-minute window

## Testing
- `npm test` *(fails: Missing script "test")*
- `node index.js`


------
https://chatgpt.com/codex/tasks/task_e_68a3e4c32dcc83288fb202c3dd80f5cf