### PR TITLE
feat: implement refresh token flow

### DIFF
--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -77,6 +77,7 @@ export interface ExpenseStats {
 export interface AuthContextType {
   user: User | null;
   token: string | null;
+  refreshToken: string | null;
   login: (email: string, password: string) => Promise<void>;
   register: (username: string, email: string, password: string) => Promise<void>;
   logout: () => void;

--- a/client/src/utils/api.ts
+++ b/client/src/utils/api.ts
@@ -27,20 +27,54 @@ api.interceptors.request.use(
 // Response interceptor to handle errors
 api.interceptors.response.use(
   (response) => response,
-  (error) => {
+  async (error) => {
+    const originalRequest = error.config as any;
     const message = error.response?.data?.message || 'An error occurred';
-    
-    if (error.response?.status === 401) {
+
+    if (
+      error.response?.status === 401 &&
+      !originalRequest._retry &&
+      !originalRequest.url?.includes('/auth/refresh') &&
+      !originalRequest.url?.includes('/auth/login') &&
+      !originalRequest.url?.includes('/auth/register')
+    ) {
+      originalRequest._retry = true;
+      const storedRefreshToken = localStorage.getItem('refreshToken');
+      if (storedRefreshToken) {
+        try {
+          const { data } = await api.post('/auth/refresh', { refreshToken: storedRefreshToken });
+          const { token: newToken, refreshToken: newRefreshToken } = data;
+          if (newToken && newRefreshToken) {
+            localStorage.setItem('token', newToken);
+            localStorage.setItem('refreshToken', newRefreshToken);
+            api.defaults.headers.common['Authorization'] = `Bearer ${newToken}`;
+            originalRequest.headers = originalRequest.headers || {};
+            originalRequest.headers['Authorization'] = `Bearer ${newToken}`;
+            window.dispatchEvent(new Event('tokenRefreshed'));
+            return api(originalRequest);
+          }
+        } catch (refreshError) {
+          // fallthrough to logout below
+        }
+      }
+
       localStorage.removeItem('token');
       localStorage.removeItem('user');
+      localStorage.removeItem('refreshToken');
+      window.dispatchEvent(new Event('tokenRefreshed'));
       window.location.href = '/login';
       toast.error('Session expired. Please login again.');
-    } else if (error.response?.status >= 500) {
+      return Promise.reject(error);
+    }
+
+    if (error.response?.status >= 500) {
       toast.error('Server error. Please try again later.');
+    } else if (error.response?.status === 401) {
+      toast.error('Unauthorized');
     } else {
       toast.error(message);
     }
-    
+
     return Promise.reject(error);
   }
 );

--- a/server/database.js
+++ b/server/database.js
@@ -38,7 +38,8 @@ db.serialize(() => {
       updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
       report_emails_enabled BOOLEAN DEFAULT 0,
       payment_cycle VARCHAR(20) DEFAULT 'monthly',
-      reminder_days_before INTEGER DEFAULT 3
+      reminder_days_before INTEGER DEFAULT 3,
+      refresh_token TEXT
     )
   `);
 
@@ -67,6 +68,14 @@ db.serialize(() => {
         db.run('ALTER TABLE users ADD COLUMN reminder_days_before INTEGER DEFAULT 3', alterErr => {
           if (alterErr) {
             console.error('Error agregando reminder_days_before:', alterErr);
+          }
+        });
+      }
+
+      if (!columns.some(col => col.name === 'refresh_token')) {
+        db.run('ALTER TABLE users ADD COLUMN refresh_token TEXT', alterErr => {
+          if (alterErr) {
+            console.error('Error agregando refresh_token:', alterErr);
           }
         });
       }


### PR DESCRIPTION
## Summary
- issue and persist refresh tokens on login and registration
- expose refresh endpoint and store tokens in auth context
- retry API calls with refresh token before logging out

## Testing
- `npm test` (fails: Missing script: "test")
- `npm --prefix server test` (fails: Missing script: "test")
- `npm --prefix client run build` (fails: TS2345 in Profile.tsx)


------
https://chatgpt.com/codex/tasks/task_e_68a3e571ea8483289a788930ff5eb58c